### PR TITLE
added explicit Nixpacks commands per app!

### DIFF
--- a/backend/nixpacks.toml
+++ b/backend/nixpacks.toml
@@ -1,14 +1,15 @@
 [variables]
 NODE_ENV = "production"
 
-[phases.setup]
-nixPkgs = ["nodejs_24", "pnpm-9_x"]
-
 [phases.install]
-cmds = ["pnpm install --frozen-lockfile"]
+cmds = [
+	"corepack enable",
+	"corepack prepare pnpm@9.15.2 --activate",
+	"pnpm install --frozen-lockfile"
+]
 
 [phases.build]
 cmds = ["pnpm run build"]
 
 [start]
-cmd = "pnpm run start:prod"
+cmd = "node dist/src/main"

--- a/frontend/nixpacks.toml
+++ b/frontend/nixpacks.toml
@@ -1,14 +1,15 @@
 [variables]
 NODE_ENV = "production"
 
-[phases.setup]
-nixPkgs = ["nodejs_24", "pnpm-9_x"]
-
 [phases.install]
-cmds = ["pnpm install --frozen-lockfile"]
+cmds = [
+	"corepack enable",
+	"corepack prepare pnpm@9.15.2 --activate",
+	"pnpm install --frozen-lockfile"
+]
 
 [phases.build]
 cmds = ["pnpm run build"]
 
 [start]
-cmd = "pnpm run start"
+cmd = "node .next/standalone/server.js"


### PR DESCRIPTION
Removed the setup phase with nixPkgs = ["nodejs_24", "pnpm-9_x"].
Added install steps:
corepack enable
corepack prepare [pnpm@9.15.2](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) --activate
pnpm install --frozen-lockfile
Kept build as pnpm run build.
Updated start commands to avoid requiring pnpm at runtime:
Backend start: node dist/src/main
Frontend start: node .next/standalone/server.js