### PR TITLE
81 dialog for creating posts buttons to edit and delete

### DIFF
--- a/backend/src/children/children.service.ts
+++ b/backend/src/children/children.service.ts
@@ -12,7 +12,10 @@ import { userChildren } from 'database/schema';
 import { CreateChildDto } from '../common/dto/create-child.dto';
 import { UpdateChildDto } from '../common/dto/update-child.dto';
 
-export type ChildWithGroup = Child & { groupId: number | null };
+export type ChildWithGroup = Child & {
+  groupId: number | null;
+  groupName: string | null;
+};
 
 function toDateOnly(value: string): Date {
   return new Date(`${value}T00:00:00.000Z`);
@@ -25,6 +28,7 @@ export class ChildrenService {
       .select({
         ...getTableColumns(children),
         groupId: enrollments.groupId,
+        groupName: groups.name,
       })
       .from(userChildren)
       .innerJoin(
@@ -35,6 +39,7 @@ export class ChildrenService {
         enrollments,
         and(eq(enrollments.childId, children.id), isNull(enrollments.deletedAt))
       )
+      .leftJoin(groups, eq(groups.id, enrollments.groupId))
       .where(eq(userChildren.userId, userId))
       .orderBy(desc(enrollments.updatedAt), desc(enrollments.id));
 
@@ -46,12 +51,14 @@ export class ChildrenService {
       .select({
         ...getTableColumns(children),
         groupId: enrollments.groupId,
+        groupName: groups.name,
       })
       .from(children)
       .leftJoin(
         enrollments,
         and(eq(enrollments.childId, children.id), isNull(enrollments.deletedAt))
       )
+      .leftJoin(groups, eq(groups.id, enrollments.groupId))
       .where(isNull(children.deletedAt))
       .orderBy(desc(enrollments.updatedAt), desc(enrollments.id));
 
@@ -65,15 +72,14 @@ export class ChildrenService {
       .select({
         ...getTableColumns(children),
         groupId: enrollments.groupId,
+        groupName: groups.name,
       })
       .from(children)
       .innerJoin(
         enrollments,
-        and(
-          eq(enrollments.childId, children.id),
-          isNull(enrollments.deletedAt),
-        )
+        and(eq(enrollments.childId, children.id), isNull(enrollments.deletedAt))
       )
+      .leftJoin(groups, eq(groups.id, enrollments.groupId))
       .where(and(eq(enrollments.groupId, groupId), isNull(children.deletedAt)))
       .orderBy(desc(enrollments.updatedAt), desc(enrollments.id));
 
@@ -110,7 +116,10 @@ export class ChildrenService {
     return this.getChildWithGroupOrThrow(createdChildId);
   }
 
-  async update(id: number, updateChildDto: UpdateChildDto): Promise<ChildWithGroup> {
+  async update(
+    id: number,
+    updateChildDto: UpdateChildDto
+  ): Promise<ChildWithGroup> {
     await this.assertChildExists(id);
 
     if (updateChildDto.groupId !== undefined) {
@@ -142,7 +151,9 @@ export class ChildrenService {
         const [latestEnrollment] = await tx
           .select({ id: enrollments.id })
           .from(enrollments)
-          .where(and(eq(enrollments.childId, id), isNull(enrollments.deletedAt)))
+          .where(
+            and(eq(enrollments.childId, id), isNull(enrollments.deletedAt))
+          )
           .orderBy(desc(enrollments.updatedAt), desc(enrollments.id))
           .limit(1);
 
@@ -179,17 +190,21 @@ export class ChildrenService {
       .where(eq(children.id, id));
   }
 
-  private async getChildWithGroupOrThrow(childId: number): Promise<ChildWithGroup> {
+  private async getChildWithGroupOrThrow(
+    childId: number
+  ): Promise<ChildWithGroup> {
     const rows = await db
       .select({
         ...getTableColumns(children),
         groupId: enrollments.groupId,
+        groupName: groups.name,
       })
       .from(children)
       .leftJoin(
         enrollments,
         and(eq(enrollments.childId, children.id), isNull(enrollments.deletedAt))
       )
+      .leftJoin(groups, eq(groups.id, enrollments.groupId))
       .where(and(eq(children.id, childId), isNull(children.deletedAt)))
       .orderBy(desc(enrollments.updatedAt), desc(enrollments.id));
 

--- a/backend/src/groups/groups.controller.ts
+++ b/backend/src/groups/groups.controller.ts
@@ -1,9 +1,27 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from '@nestjs/common';
-import { ApiBody, ApiCookieAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { Request } from 'express';
+import {
+  ApiBody,
+  ApiCookieAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
-import { ROLE } from 'database/schema';
+import { ROLE, User } from 'database/schema';
 import { GroupsService, GroupWithDetails, TeacherUser } from './groups.service';
 import { CreateGroupDto } from '../common/dto/create-group.dto';
 import { UpdateGroupDto } from '../common/dto/update-group.dto';
@@ -17,18 +35,32 @@ export class GroupsController {
 
   @Get()
   @Roles(ROLE.Admin, ROLE.Teacher)
-  @ApiOperation({ summary: 'Get all groups with children count and assigned teachers (ADMIN/TEACHER only)' })
+  @ApiOperation({
+    summary:
+      'Get all groups with children count and assigned teachers (ADMIN/TEACHER only)',
+  })
   @ApiResponse({ status: 200, description: 'Groups returned successfully.' })
-  @ApiResponse({ status: 403, description: 'Forbidden — only ADMIN or TEACHER role can list groups.' })
-  async findAll(): Promise<GroupWithDetails[]> {
-    return this.groupsService.findAll();
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — only ADMIN or TEACHER role can list groups.',
+  })
+  async findAll(
+    @Req() req: Request & { user?: User }
+  ): Promise<GroupWithDetails[]> {
+    return this.groupsService.findAll(req.user!);
   }
 
   @Get('teachers')
   @Roles(ROLE.Admin)
-  @ApiOperation({ summary: 'Get all users with TEACHER role available for group assignment (ADMIN only)' })
+  @ApiOperation({
+    summary:
+      'Get all users with TEACHER role available for group assignment (ADMIN only)',
+  })
   @ApiResponse({ status: 200, description: 'Teachers returned successfully.' })
-  @ApiResponse({ status: 403, description: 'Forbidden — only ADMIN role can access this endpoint.' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — only ADMIN role can access this endpoint.',
+  })
   async findTeachers(): Promise<TeacherUser[]> {
     return this.groupsService.findTeachers();
   }
@@ -38,24 +70,43 @@ export class GroupsController {
   @ApiOperation({ summary: 'Create a new group (ADMIN only)' })
   @ApiBody({ type: CreateGroupDto })
   @ApiResponse({ status: 201, description: 'Group created successfully.' })
-  @ApiResponse({ status: 400, description: 'Validation error — invalid request body or invalid teacher IDs.' })
-  @ApiResponse({ status: 403, description: 'Forbidden — only ADMIN role can create groups.' })
-  async create(@Body() createGroupDto: CreateGroupDto): Promise<GroupWithDetails> {
+  @ApiResponse({
+    status: 400,
+    description:
+      'Validation error — invalid request body or invalid teacher IDs.',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — only ADMIN role can create groups.',
+  })
+  async create(
+    @Body() createGroupDto: CreateGroupDto
+  ): Promise<GroupWithDetails> {
     return this.groupsService.create(createGroupDto);
   }
 
   @Patch(':id')
   @Roles(ROLE.Admin)
-  @ApiOperation({ summary: 'Update an existing group (ADMIN only). Provide teacherIds to fully replace teacher assignments; omit to leave unchanged.' })
+  @ApiOperation({
+    summary:
+      'Update an existing group (ADMIN only). Provide teacherIds to fully replace teacher assignments; omit to leave unchanged.',
+  })
   @ApiParam({ name: 'id', type: Number, description: 'Group ID' })
   @ApiBody({ type: UpdateGroupDto })
   @ApiResponse({ status: 200, description: 'Group updated successfully.' })
-  @ApiResponse({ status: 400, description: 'Validation error — invalid request body or invalid teacher IDs.' })
-  @ApiResponse({ status: 403, description: 'Forbidden — only ADMIN role can update groups.' })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Validation error — invalid request body or invalid teacher IDs.',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — only ADMIN role can update groups.',
+  })
   @ApiResponse({ status: 404, description: 'Group not found.' })
   async update(
     @Param('id', ParseIntPipe) id: number,
-    @Body() updateGroupDto: UpdateGroupDto,
+    @Body() updateGroupDto: UpdateGroupDto
   ): Promise<GroupWithDetails> {
     return this.groupsService.update(id, updateGroupDto);
   }

--- a/backend/src/groups/groups.service.ts
+++ b/backend/src/groups/groups.service.ts
@@ -1,7 +1,30 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { db } from 'database/db';
-import { Group, groups, enrollments, groupUsers, users, ROLE, TEACHER_ROLE, TeacherRoleType } from 'database/schema';
-import { and, asc, count, eq, getTableColumns, inArray, isNull, sql } from 'drizzle-orm';
+import {
+  Group,
+  groups,
+  enrollments,
+  groupUsers,
+  users,
+  ROLE,
+  TEACHER_ROLE,
+  TeacherRoleType,
+  User,
+} from 'database/schema';
+import {
+  and,
+  asc,
+  count,
+  eq,
+  getTableColumns,
+  inArray,
+  isNull,
+  sql,
+} from 'drizzle-orm';
 import { CreateGroupDto } from '../common/dto/create-group.dto';
 import { UpdateGroupDto } from '../common/dto/update-group.dto';
 
@@ -26,12 +49,26 @@ export type GroupWithDetails = Group & {
 
 @Injectable()
 export class GroupsService {
-  async findAll(): Promise<GroupWithDetails[]> {
-    const allGroups = await db
-      .select(getTableColumns(groups))
-      .from(groups)
-      .where(isNull(groups.deletedAt))
-      .orderBy(asc(groups.name));
+  async findAll(user: User): Promise<GroupWithDetails[]> {
+    const allGroups =
+      user.role === ROLE.Teacher
+        ? await db
+            .selectDistinct(getTableColumns(groups))
+            .from(groups)
+            .innerJoin(
+              groupUsers,
+              and(
+                eq(groupUsers.groupId, groups.id),
+                eq(groupUsers.userId, user.id)
+              )
+            )
+            .where(isNull(groups.deletedAt))
+            .orderBy(asc(groups.name))
+        : await db
+            .select(getTableColumns(groups))
+            .from(groups)
+            .where(isNull(groups.deletedAt))
+            .orderBy(asc(groups.name));
 
     if (allGroups.length === 0) {
       return [];
@@ -62,12 +99,22 @@ export class GroupsService {
       })
       .from(groupUsers)
       .innerJoin(users, eq(groupUsers.userId, users.id))
-      .where(sql`${groupUsers.groupId} = ANY(ARRAY[${sql.join(groupIds.map((id) => sql`${id}`), sql`, `)}]::int[])`);
+      .where(
+        sql`${groupUsers.groupId} = ANY(ARRAY[${sql.join(
+          groupIds.map((id) => sql`${id}`),
+          sql`, `
+        )}]::int[])`
+      );
 
     const teacherMap = new Map<number, GroupTeacher[]>();
     for (const row of teacherRows) {
       const list = teacherMap.get(row.groupId) ?? [];
-      list.push({ id: row.id, firstName: row.firstName, lastName: row.lastName, role: row.role });
+      list.push({
+        id: row.id,
+        firstName: row.firstName,
+        lastName: row.lastName,
+        role: row.role,
+      });
       teacherMap.set(row.groupId, list);
     }
 
@@ -134,10 +181,12 @@ export class GroupsService {
     const updateData: Partial<Group> = {};
 
     if (dto.name !== undefined) updateData.name = dto.name.trim();
-    if (dto.description !== undefined) updateData.description = dto.description.trim() || null;
+    if (dto.description !== undefined)
+      updateData.description = dto.description.trim() || null;
     if (dto.ageMin !== undefined) updateData.ageMin = dto.ageMin;
     if (dto.ageMax !== undefined) updateData.ageMax = dto.ageMax;
-    if (dto.kindergartenName !== undefined) updateData.kindergartenName = dto.kindergartenName.trim() || null;
+    if (dto.kindergartenName !== undefined)
+      updateData.kindergartenName = dto.kindergartenName.trim() || null;
 
     if (Object.keys(updateData).length > 0) {
       updateData.updatedAt = new Date();
@@ -201,12 +250,20 @@ export class GroupsService {
     const found = await db
       .select({ id: users.id })
       .from(users)
-      .where(and(inArray(users.id, userIds), eq(users.role, ROLE.Teacher), isNull(users.deletedAt)));
+      .where(
+        and(
+          inArray(users.id, userIds),
+          eq(users.role, ROLE.Teacher),
+          isNull(users.deletedAt)
+        )
+      );
 
     if (found.length !== userIds.length) {
       const foundIds = new Set(found.map((u) => u.id));
       const invalid = userIds.filter((id) => !foundIds.has(id));
-      throw new BadRequestException(`User IDs are not valid teachers: ${invalid.join(', ')}`);
+      throw new BadRequestException(
+        `User IDs are not valid teachers: ${invalid.join(', ')}`
+      );
     }
   }
 

--- a/backend/src/posts/posts.controller.ts
+++ b/backend/src/posts/posts.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Get, Post, Patch, Body, Param, UseGuards, Req, ParseIntPipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Req,
+  ParseIntPipe,
+} from '@nestjs/common';
 import { Request } from 'express';
 import { PostsService } from './posts.service';
 import {
@@ -28,10 +39,19 @@ export class PostsController {
   @ApiOperation({ summary: 'Create a new announcement (TEACHER only)' })
   @ApiBody({ type: CreatePostDto })
   @ApiResponse({ status: 201, description: 'Post created successfully.' })
-  @ApiResponse({ status: 400, description: 'Validation error — invalid request body.' })
-  @ApiResponse({ status: 403, description: 'Forbidden — only TEACHER role can create posts.' })
+  @ApiResponse({
+    status: 400,
+    description: 'Validation error — invalid request body.',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — only TEACHER role can create posts.',
+  })
   @ApiResponse({ status: 404, description: 'Group not found.' })
-  async create(@Body() createPostDto: CreatePostDto, @Req() req: Request & { user?: User }): Promise<PostEntity[]> {
+  async create(
+    @Body() createPostDto: CreatePostDto,
+    @Req() req: Request & { user?: User }
+  ): Promise<PostEntity[]> {
     return this.postsService.create(createPostDto, req.user!.id);
   }
 
@@ -41,25 +61,53 @@ export class PostsController {
   @ApiParam({ name: 'id', type: Number, description: 'Post ID' })
   @ApiBody({ type: UpdatePostDto })
   @ApiResponse({ status: 200, description: 'Post updated successfully.' })
-  @ApiResponse({ status: 400, description: 'Validation error — invalid request body.' })
-  @ApiResponse({ status: 403, description: 'Forbidden — only TEACHER or ADMIN role can update posts.' })
+  @ApiResponse({
+    status: 400,
+    description: 'Validation error — invalid request body.',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — only TEACHER or ADMIN role can update posts.',
+  })
   @ApiResponse({ status: 404, description: 'Post not found.' })
   async update(
     @Param('id', ParseIntPipe) id: number,
-    @Body() updatePostDto: UpdatePostDto,
+    @Body() updatePostDto: UpdatePostDto
   ): Promise<PostEntity> {
     return this.postsService.update(id, updatePostDto);
   }
 
+  @Delete(':id')
+  @Roles(ROLE.Teacher, ROLE.Admin)
+  @ApiOperation({ summary: 'Delete an existing post (TEACHER only)' })
+  @ApiParam({ name: 'id', type: Number, description: 'Post ID' })
+  @ApiResponse({ status: 200, description: 'Post deleted successfully.' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — only TEACHER role can delete posts.',
+  })
+  @ApiResponse({ status: 404, description: 'Post not found.' })
+  async delete(
+    @Param('id', ParseIntPipe) id: number
+  ): Promise<{ success: true }> {
+    await this.postsService.delete(id);
+    return { success: true };
+  }
+
   @Get('group/:id')
-  @ApiOperation({ summary: 'Get all posts for a group ordered by newest first' })
+  @ApiOperation({
+    summary: 'Get all posts for a group ordered by newest first',
+  })
   @ApiParam({ name: 'id', type: Number, description: 'Group ID' })
   @ApiResponse({ status: 200, description: 'Posts returned successfully.' })
-  @ApiResponse({ status: 403, description: 'Forbidden — PARENT does not have a child in this group.' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — PARENT does not have a child in this group.',
+  })
   @ApiResponse({ status: 404, description: 'Group not found.' })
   async findByGroup(
     @Param('id', ParseIntPipe) id: number,
-    @Req() req: Request & { user?: User },
+    @Req() req: Request & { user?: User }
   ): Promise<PostEntity[]> {
     return this.postsService.findByGroup(id, req.user!);
   }

--- a/backend/src/posts/posts.controller.ts
+++ b/backend/src/posts/posts.controller.ts
@@ -35,8 +35,8 @@ export class PostsController {
   constructor(private readonly postsService: PostsService) {}
 
   @Post()
-  @Roles(ROLE.Teacher)
-  @ApiOperation({ summary: 'Create a new announcement (TEACHER only)' })
+  @Roles(ROLE.Teacher, ROLE.Admin)
+  @ApiOperation({ summary: 'Create a new announcement (TEACHER/ADMIN only)' })
   @ApiBody({ type: CreatePostDto })
   @ApiResponse({ status: 201, description: 'Post created successfully.' })
   @ApiResponse({
@@ -45,7 +45,7 @@ export class PostsController {
   })
   @ApiResponse({
     status: 403,
-    description: 'Forbidden — only TEACHER role can create posts.',
+    description: 'Forbidden — only TEACHER or ADMIN role can create posts.',
   })
   @ApiResponse({ status: 404, description: 'Group not found.' })
   async create(
@@ -79,12 +79,12 @@ export class PostsController {
 
   @Delete(':id')
   @Roles(ROLE.Teacher, ROLE.Admin)
-  @ApiOperation({ summary: 'Delete an existing post (TEACHER only)' })
+  @ApiOperation({ summary: 'Delete an existing post (TEACHER/ADMIN only)' })
   @ApiParam({ name: 'id', type: Number, description: 'Post ID' })
   @ApiResponse({ status: 200, description: 'Post deleted successfully.' })
   @ApiResponse({
     status: 403,
-    description: 'Forbidden — only TEACHER role can delete posts.',
+    description: 'Forbidden — only TEACHER or ADMIN role can delete posts.',
   })
   @ApiResponse({ status: 404, description: 'Post not found.' })
   async delete(

--- a/backend/src/posts/posts.service.ts
+++ b/backend/src/posts/posts.service.ts
@@ -14,7 +14,7 @@ import {
   userChildren,
   enrollments,
 } from 'database/schema';
-import { eq, desc, and } from 'drizzle-orm';
+import { eq, desc, and, isNull } from 'drizzle-orm';
 import { UpdatePostDto } from '../common/dto/update-post.dto';
 
 @Injectable()
@@ -42,7 +42,7 @@ export class PostsService {
 
   async update(postId: number, updatePostDto: UpdatePostDto): Promise<Post> {
     const existing = await db.query.posts.findFirst({
-      where: eq(posts.id, postId),
+      where: and(eq(posts.id, postId), isNull(posts.deletedAt)),
     });
     if (!existing) {
       throw new NotFoundException(`Post ${postId} not found`);
@@ -66,6 +66,24 @@ export class PostsService {
     return updated;
   }
 
+  async delete(postId: number): Promise<void> {
+    const existing = await db.query.posts.findFirst({
+      where: and(eq(posts.id, postId), isNull(posts.deletedAt)),
+    });
+
+    if (!existing) {
+      throw new NotFoundException(`Post ${postId} not found`);
+    }
+
+    await db
+      .update(posts)
+      .set({
+        deletedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(posts.id, postId));
+  }
+
   async findByGroup(groupId: number, user: User): Promise<Post[]> {
     await this.assertGroupExists(groupId);
     await this.assertUserCanAccessGroup(groupId, user);
@@ -73,7 +91,7 @@ export class PostsService {
     return db
       .select()
       .from(posts)
-      .where(eq(posts.groupId, groupId))
+      .where(and(eq(posts.groupId, groupId), isNull(posts.deletedAt)))
       .orderBy(desc(posts.createdAt));
   }
 

--- a/backend/test/children/children.controller.spec.ts
+++ b/backend/test/children/children.controller.spec.ts
@@ -21,6 +21,7 @@ describe('ChildrenController', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       groupId: 5,
+      groupName: 'Mesimummud',
     },
   ];
 
@@ -35,6 +36,7 @@ describe('ChildrenController', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       groupId: 1,
+      groupName: 'Lepatriinud',
     },
     {
       id: 2,
@@ -46,6 +48,7 @@ describe('ChildrenController', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       groupId: 1,
+      groupName: 'Lepatriinud',
     },
   ];
 
@@ -59,6 +62,7 @@ describe('ChildrenController', () => {
     createdAt: new Date(),
     updatedAt: new Date(),
     groupId: 7,
+    groupName: 'Sipsikud',
   };
 
   const mockUngroupedChild: ChildWithGroup = {
@@ -71,6 +75,7 @@ describe('ChildrenController', () => {
     createdAt: new Date(),
     updatedAt: new Date(),
     groupId: null,
+    groupName: null,
   };
 
   beforeEach(async () => {
@@ -163,7 +168,9 @@ describe('ChildrenController', () => {
         lastName: 'Group',
         dateOfBirth: '2021-03-05',
       };
-      jest.spyOn(childrenService, 'create').mockResolvedValueOnce(mockUngroupedChild);
+      jest
+        .spyOn(childrenService, 'create')
+        .mockResolvedValueOnce(mockUngroupedChild);
 
       const result = await controller.create(payload);
 

--- a/backend/test/groups/groups.controller.spec.ts
+++ b/backend/test/groups/groups.controller.spec.ts
@@ -83,9 +83,10 @@ describe('GroupsController', () => {
 
   describe('findAll', () => {
     it('should return all groups with details', async () => {
-      const result = await controller.findAll();
+      const req = { user: { id: 1, role: 'ADMIN' } } as any;
+      const result = await controller.findAll(req);
 
-      expect(groupsService.findAll).toHaveBeenCalled();
+      expect(groupsService.findAll).toHaveBeenCalledWith(req.user);
       expect(result).toEqual(mockGroups);
     });
   });
@@ -236,9 +237,10 @@ describe('GroupsController', () => {
 
   describe('findAll', () => {
     it('should return all groups with details', async () => {
-      const result = await controller.findAll();
+      const req = { user: { id: 1, role: 'ADMIN' } } as any;
+      const result = await controller.findAll(req);
 
-      expect(groupsService.findAll).toHaveBeenCalled();
+      expect(groupsService.findAll).toHaveBeenCalledWith(req.user);
       expect(result).toEqual(mockGroups);
     });
   });

--- a/backend/test/groups/groups.controller.spec.ts
+++ b/backend/test/groups/groups.controller.spec.ts
@@ -1,7 +1,31 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Request } from 'express';
+import { ROLE, User } from '../../src/database/schema';
 import { GroupsController } from '../../src/groups/groups.controller';
-import { GroupsService, GroupWithDetails, TeacherUser } from '../../src/groups/groups.service';
+import {
+  GroupsService,
+  GroupWithDetails,
+  TeacherUser,
+} from '../../src/groups/groups.service';
+
+function createRequestWithUser(user: Partial<User>): Request & { user: User } {
+  return {
+    user: {
+      id: 1,
+      role: ROLE.Admin,
+      email: 'admin@test.com',
+      firstName: null,
+      lastName: null,
+      phone: null,
+      googleId: null,
+      deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...user,
+    },
+  } as Request & { user: User };
+}
 
 describe('GroupsController', () => {
   let controller: GroupsController;
@@ -26,7 +50,9 @@ describe('GroupsController', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       childrenCount: 3,
-      teachers: [{ id: 10, firstName: 'Mari', lastName: 'Mets', role: 'GENERAL' }],
+      teachers: [
+        { id: 10, firstName: 'Mari', lastName: 'Mets', role: 'GENERAL' },
+      ],
     },
     {
       id: 2,
@@ -54,7 +80,9 @@ describe('GroupsController', () => {
     createdAt: new Date(),
     updatedAt: new Date(),
     childrenCount: 0,
-    teachers: [{ id: 10, firstName: 'Mari', lastName: 'Mets', role: 'GENERAL' }],
+    teachers: [
+      { id: 10, firstName: 'Mari', lastName: 'Mets', role: 'GENERAL' },
+    ],
   };
 
   beforeEach(async () => {
@@ -67,7 +95,9 @@ describe('GroupsController', () => {
             findAll: jest.fn().mockResolvedValue(mockGroups),
             findTeachers: jest.fn().mockResolvedValue([mockTeacher]),
             create: jest.fn().mockResolvedValue(mockCreatedGroup),
-            update: jest.fn().mockResolvedValue({ ...mockGroups[0], name: 'Updated Ants' }),
+            update: jest
+              .fn()
+              .mockResolvedValue({ ...mockGroups[0], name: 'Updated Ants' }),
           },
         },
       ],
@@ -83,7 +113,7 @@ describe('GroupsController', () => {
 
   describe('findAll', () => {
     it('should return all groups with details', async () => {
-      const req = { user: { id: 1, role: 'ADMIN' } } as any;
+      const req = createRequestWithUser({});
       const result = await controller.findAll(req);
 
       expect(groupsService.findAll).toHaveBeenCalledWith(req.user);
@@ -102,7 +132,13 @@ describe('GroupsController', () => {
 
   describe('create', () => {
     it('should create and return a group without teachers', async () => {
-      const dto = { name: 'Foxes', description: 'Fast and clever', ageMin: '4', ageMax: '6', kindergartenName: 'Forest Kindergarten' };
+      const dto = {
+        name: 'Foxes',
+        description: 'Fast and clever',
+        ageMin: '4',
+        ageMax: '6',
+        kindergartenName: 'Forest Kindergarten',
+      };
 
       const result = await controller.create(dto);
 
@@ -119,9 +155,13 @@ describe('GroupsController', () => {
     });
 
     it('should propagate BadRequestException for invalid teacher IDs', async () => {
-      (groupsService.create as jest.Mock).mockRejectedValue(new BadRequestException('User IDs are not valid teachers: 99'));
+      (groupsService.create as jest.Mock).mockRejectedValue(
+        new BadRequestException('User IDs are not valid teachers: 99')
+      );
 
-      await expect(controller.create({ name: 'Foxes', teacherIds: [99] })).rejects.toThrow(BadRequestException);
+      await expect(
+        controller.create({ name: 'Foxes', teacherIds: [99] })
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
@@ -152,15 +192,23 @@ describe('GroupsController', () => {
     });
 
     it('should propagate NotFoundException from service', async () => {
-      (groupsService.update as jest.Mock).mockRejectedValue(new NotFoundException('Group with id 99999 not found'));
+      (groupsService.update as jest.Mock).mockRejectedValue(
+        new NotFoundException('Group with id 99999 not found')
+      );
 
-      await expect(controller.update(99999, { name: 'Ghost' })).rejects.toThrow(NotFoundException);
+      await expect(controller.update(99999, { name: 'Ghost' })).rejects.toThrow(
+        NotFoundException
+      );
     });
 
     it('should propagate BadRequestException for invalid teacher IDs', async () => {
-      (groupsService.update as jest.Mock).mockRejectedValue(new BadRequestException('User IDs are not valid teachers: 99'));
+      (groupsService.update as jest.Mock).mockRejectedValue(
+        new BadRequestException('User IDs are not valid teachers: 99')
+      );
 
-      await expect(controller.update(1, { teacherIds: [99] })).rejects.toThrow(BadRequestException);
+      await expect(controller.update(1, { teacherIds: [99] })).rejects.toThrow(
+        BadRequestException
+      );
     });
   });
 });
@@ -181,7 +229,9 @@ describe('GroupsController', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       childrenCount: 3,
-      teachers: [{ id: 10, firstName: 'Mari', lastName: 'Mets', role: 'GENERAL' }],
+      teachers: [
+        { id: 10, firstName: 'Mari', lastName: 'Mets', role: 'GENERAL' },
+      ],
     },
     {
       id: 2,
@@ -221,7 +271,9 @@ describe('GroupsController', () => {
           useValue: {
             findAll: jest.fn().mockResolvedValue(mockGroups),
             create: jest.fn().mockResolvedValue(mockCreatedGroup),
-            update: jest.fn().mockResolvedValue({ ...mockGroups[0], name: 'Updated Ants' }),
+            update: jest
+              .fn()
+              .mockResolvedValue({ ...mockGroups[0], name: 'Updated Ants' }),
           },
         },
       ],
@@ -237,7 +289,7 @@ describe('GroupsController', () => {
 
   describe('findAll', () => {
     it('should return all groups with details', async () => {
-      const req = { user: { id: 1, role: 'ADMIN' } } as any;
+      const req = createRequestWithUser({});
       const result = await controller.findAll(req);
 
       expect(groupsService.findAll).toHaveBeenCalledWith(req.user);
@@ -247,7 +299,13 @@ describe('GroupsController', () => {
 
   describe('create', () => {
     it('should create and return a group', async () => {
-      const dto = { name: 'Foxes', description: 'Fast and clever', ageMin: '4', ageMax: '6', kindergartenName: 'Forest Kindergarten' };
+      const dto = {
+        name: 'Foxes',
+        description: 'Fast and clever',
+        ageMin: '4',
+        ageMax: '6',
+        kindergartenName: 'Forest Kindergarten',
+      };
 
       const result = await controller.create(dto);
 
@@ -267,9 +325,13 @@ describe('GroupsController', () => {
     });
 
     it('should propagate NotFoundException from service', async () => {
-      (groupsService.update as jest.Mock).mockRejectedValue(new NotFoundException('Group with id 99999 not found'));
+      (groupsService.update as jest.Mock).mockRejectedValue(
+        new NotFoundException('Group with id 99999 not found')
+      );
 
-      await expect(controller.update(99999, { name: 'Ghost' })).rejects.toThrow(NotFoundException);
+      await expect(controller.update(99999, { name: 'Ghost' })).rejects.toThrow(
+        NotFoundException
+      );
     });
   });
 });

--- a/backend/test/groups/groups.service.e2e-spec.ts
+++ b/backend/test/groups/groups.service.e2e-spec.ts
@@ -21,17 +21,25 @@ describe('GroupsService (e2e)', () => {
 
   describe('findAll', () => {
     it('should return an empty array when there are no groups', async () => {
-      const result = await service.findAll();
+      const admin = await createTestUser(
+        'findall-empty-admin@test.com',
+        ROLE.Admin
+      );
+      const result = await service.findAll(admin);
 
       expect(result).toEqual([]);
     });
 
     it('should return groups ordered by name ascending', async () => {
+      const admin = await createTestUser(
+        'findall-order-admin@test.com',
+        ROLE.Admin
+      );
       await createTestGroup('Zebras');
       await createTestGroup('Ants');
       await createTestGroup('Bumblebees');
 
-      const result = await service.findAll();
+      const result = await service.findAll(admin);
 
       expect(result.map((group) => group.name)).toEqual([
         'Ants',
@@ -41,13 +49,17 @@ describe('GroupsService (e2e)', () => {
     });
 
     it('should include childrenCount for enrolled children', async () => {
+      const admin = await createTestUser(
+        'findall-children-admin@test.com',
+        ROLE.Admin
+      );
       const group = await createTestGroup('Otters');
       const child1 = await createTestChild('Alice', 'Smith');
       const child2 = await createTestChild('Bob', 'Jones');
       await createTestEnrollment(child1.id, group.id);
       await createTestEnrollment(child2.id, group.id);
 
-      const result = await service.findAll();
+      const result = await service.findAll(admin);
       const found = result.find((g) => g.id === group.id);
 
       expect(found).toBeDefined();
@@ -55,6 +67,10 @@ describe('GroupsService (e2e)', () => {
     });
 
     it('should include teachers list for assigned teachers', async () => {
+      const admin = await createTestUser(
+        'findall-teachers-admin@test.com',
+        ROLE.Admin
+      );
       const group = await createTestGroup('Wolves');
       const teacher = await createTestUser('teacher@wolves.com', ROLE.Teacher, {
         firstName: 'Kati',
@@ -62,7 +78,7 @@ describe('GroupsService (e2e)', () => {
       });
       await createTestGroupUser(group.id, teacher.id, TEACHER_ROLE.Head);
 
-      const result = await service.findAll();
+      const result = await service.findAll(admin);
       const found = result.find((g) => g.id === group.id);
 
       expect(found).toBeDefined();
@@ -76,14 +92,37 @@ describe('GroupsService (e2e)', () => {
     });
 
     it('should return childrenCount 0 and empty teachers for group with no members', async () => {
+      const admin = await createTestUser(
+        'findall-members-admin@test.com',
+        ROLE.Admin
+      );
       const group = await createTestGroup('Empty Group');
 
-      const result = await service.findAll();
+      const result = await service.findAll(admin);
       const found = result.find((g) => g.id === group.id);
 
       expect(found).toBeDefined();
       expect(found!.childrenCount).toBe(0);
       expect(found!.teachers).toEqual([]);
+    });
+
+    it('should return only assigned groups for a teacher', async () => {
+      const teacher = await createTestUser(
+        'assigned-teacher@test.com',
+        ROLE.Teacher
+      );
+      const assignedGroup = await createTestGroup('Assigned Group');
+      await createTestGroup('Other Group');
+      await createTestGroupUser(
+        assignedGroup.id,
+        teacher.id,
+        TEACHER_ROLE.General
+      );
+
+      const result = await service.findAll(teacher);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(assignedGroup.id);
     });
   });
 
@@ -131,14 +170,19 @@ describe('GroupsService (e2e)', () => {
     it('should update ageMin and ageMax', async () => {
       const group = await createTestGroup('Age Group');
 
-      const result = await service.update(group.id, { ageMin: '2', ageMax: '4' });
+      const result = await service.update(group.id, {
+        ageMin: '2',
+        ageMax: '4',
+      });
 
       expect(result.ageMin).toBe('2');
       expect(result.ageMax).toBe('4');
     });
 
     it('should throw NotFoundException when group does not exist', async () => {
-      await expect(service.update(99999, { name: 'Ghost' })).rejects.toThrow(NotFoundException);
+      await expect(service.update(99999, { name: 'Ghost' })).rejects.toThrow(
+        NotFoundException
+      );
     });
 
     it('should include childrenCount and teachers in update result', async () => {
@@ -146,7 +190,9 @@ describe('GroupsService (e2e)', () => {
       const child = await createTestChild('Tina', 'Doe');
       await createTestEnrollment(child.id, group.id);
 
-      const result = await service.update(group.id, { description: 'Updated desc' });
+      const result = await service.update(group.id, {
+        description: 'Updated desc',
+      });
 
       expect(result.childrenCount).toBe(1);
       expect(result.teachers).toEqual([]);
@@ -159,10 +205,16 @@ describe('GroupsService (e2e)', () => {
         lastName: 'Teacher',
       });
 
-      const result = await service.update(group.id, { teacherIds: [teacher.id] });
+      const result = await service.update(group.id, {
+        teacherIds: [teacher.id],
+      });
 
       expect(result.teachers).toHaveLength(1);
-      expect(result.teachers[0]).toMatchObject({ id: teacher.id, firstName: 'Assign', lastName: 'Teacher' });
+      expect(result.teachers[0]).toMatchObject({
+        id: teacher.id,
+        firstName: 'Assign',
+        lastName: 'Teacher',
+      });
     });
 
     it('should replace existing teachers when teacherIds is provided', async () => {
@@ -174,7 +226,9 @@ describe('GroupsService (e2e)', () => {
       });
       await createTestGroupUser(group.id, oldTeacher.id, TEACHER_ROLE.General);
 
-      const result = await service.update(group.id, { teacherIds: [newTeacher.id] });
+      const result = await service.update(group.id, {
+        teacherIds: [newTeacher.id],
+      });
 
       expect(result.teachers).toHaveLength(1);
       expect(result.teachers[0].id).toBe(newTeacher.id);
@@ -198,7 +252,9 @@ describe('GroupsService (e2e)', () => {
       });
       await createTestGroupUser(group.id, teacher.id, TEACHER_ROLE.General);
 
-      const result = await service.update(group.id, { name: 'Keep Teachers Renamed' });
+      const result = await service.update(group.id, {
+        name: 'Keep Teachers Renamed',
+      });
 
       expect(result.teachers).toHaveLength(1);
       expect(result.teachers[0].id).toBe(teacher.id);
@@ -208,34 +264,55 @@ describe('GroupsService (e2e)', () => {
       const group = await createTestGroup('Bad Teacher');
       const adminUser = await createTestUser('admin@test.com', ROLE.Admin);
 
-      await expect(service.update(group.id, { teacherIds: [adminUser.id] })).rejects.toThrow(BadRequestException);
+      await expect(
+        service.update(group.id, { teacherIds: [adminUser.id] })
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
   describe('create with teachers', () => {
     it('should create a group and assign teachers', async () => {
-      const teacher = await createTestUser('create-assign@teacher.com', ROLE.Teacher, {
+      const teacher = await createTestUser(
+        'create-assign@teacher.com',
+        ROLE.Teacher,
+        {
+          firstName: 'Kati',
+          lastName: 'Lepp',
+        }
+      );
+
+      const result = await service.create({
+        name: 'With Teachers',
+        teacherIds: [teacher.id],
+      });
+
+      expect(result.teachers).toHaveLength(1);
+      expect(result.teachers[0]).toMatchObject({
+        id: teacher.id,
         firstName: 'Kati',
         lastName: 'Lepp',
       });
-
-      const result = await service.create({ name: 'With Teachers', teacherIds: [teacher.id] });
-
-      expect(result.teachers).toHaveLength(1);
-      expect(result.teachers[0]).toMatchObject({ id: teacher.id, firstName: 'Kati', lastName: 'Lepp' });
     });
 
     it('should throw BadRequestException when a teacherId in create is not a teacher', async () => {
       const parent = await createTestUser('parent@test.com', ROLE.Parent);
 
-      await expect(service.create({ name: 'Bad Create', teacherIds: [parent.id] })).rejects.toThrow(BadRequestException);
+      await expect(
+        service.create({ name: 'Bad Create', teacherIds: [parent.id] })
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
   describe('findTeachers', () => {
     it('should return all users with TEACHER role', async () => {
-      const teacher1 = await createTestUser('t1@test.com', ROLE.Teacher, { firstName: 'Alpha', lastName: 'T' });
-      const teacher2 = await createTestUser('t2@test.com', ROLE.Teacher, { firstName: 'Beta', lastName: 'T' });
+      const teacher1 = await createTestUser('t1@test.com', ROLE.Teacher, {
+        firstName: 'Alpha',
+        lastName: 'T',
+      });
+      const teacher2 = await createTestUser('t2@test.com', ROLE.Teacher, {
+        firstName: 'Beta',
+        lastName: 'T',
+      });
       await createTestUser('admin@findtest.com', ROLE.Admin);
 
       const result = await service.findTeachers();

--- a/frontend/src/app/(main)/dashboard/DashboardFeedCard.tsx
+++ b/frontend/src/app/(main)/dashboard/DashboardFeedCard.tsx
@@ -26,18 +26,9 @@ function formatDashboardCardDate(value: string): string {
   }
 }
 
-function getDashboardCardHeading(item: DashboardFeedItem): string {
-  if (item.groupName) {
-    return `Päevakokkuvõte - ${item.groupName}`;
-  }
-
-  return item.title;
-}
-
 export function DashboardFeedCard({ item }: DashboardFeedCardProps) {
   const hasStatus = item.status != null;
   const isPresent = item.status === 'PRESENT';
-  const heading = getDashboardCardHeading(item);
 
   return (
     <Card variant="outlined" elevation={0} sx={{ bgcolor: 'background.paper' }}>
@@ -52,6 +43,27 @@ export function DashboardFeedCard({ item }: DashboardFeedCardProps) {
           >
             {formatDashboardCardDate(item.date)}
           </Typography>
+
+          <Typography
+            component="h2"
+            variant="subtitle1"
+            fontWeight={600}
+            sx={{ color: 'text.primary', mb: 1.5 }}
+          >
+            {item.title}
+          </Typography>
+
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mt: 1.5, lineHeight: 1.6 }}
+            >
+              {item.description}
+            </Typography>
+          </Box>
+
+          {hasStatus ? <Divider sx={{ my: 1.5 }} /> : null}
 
           {hasStatus ? (
             <Box
@@ -75,55 +87,11 @@ export function DashboardFeedCard({ item }: DashboardFeedCardProps) {
                   )}
                   sx={{ fontWeight: 600 }}
                 >
-                  {isPresent ? 'Present' : 'Absent'}
+                  {isPresent ? 'Kohal' : 'Puudus'}
                 </Typography>
               </Box>
             </Box>
           ) : null}
-
-          {hasStatus ? <Divider sx={{ my: 1.5 }} /> : null}
-
-          <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Typography
-              component="h2"
-              variant="subtitle1"
-              fontWeight={600}
-              sx={{ color: 'text.primary', mb: 1.5 }}
-            >
-              {heading}
-            </Typography>
-            {item.childName && hasStatus ? (
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                sx={{ mb: 1.5, fontWeight: 500 }}
-              >
-                {item.childName}
-              </Typography>
-            ) : null}
-            {item.groupName && !hasStatus ? (
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                sx={{ mb: 1.5, fontWeight: 500 }}
-              >
-                {item.title}
-              </Typography>
-            ) : null}
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{
-                mt: 1.5,
-                pl: 1.5,
-                borderLeft: 2,
-                borderColor: 'divider',
-                lineHeight: 1.6,
-              }}
-            >
-              {item.description}
-            </Typography>
-          </Box>
         </Box>
       </CardContent>
     </Card>

--- a/frontend/src/app/(main)/dashboard/DashboardFeedCard.tsx
+++ b/frontend/src/app/(main)/dashboard/DashboardFeedCard.tsx
@@ -26,27 +26,20 @@ function formatDashboardCardDate(value: string): string {
   }
 }
 
-function splitDashboardCardTitle(title: string): {
-  heading: string;
-} {
-  if (!title.includes(' - ')) {
-    return {
-      heading: title,
-    };
+function getDashboardCardHeading(item: DashboardFeedItem): string {
+  if (item.status != null) {
+    return item.groupName
+      ? `Päevakokkuvõte - ${item.groupName}`
+      : 'Päevakokkuvõte';
   }
 
-  const [, ...rest] = title.split(' - ');
-  const groupName = rest.join(' - ').trim();
-
-  return {
-    heading: groupName ? `Päevakokkuvõte - ${groupName}` : 'Päevakokkuvõte',
-  };
+  return item.title;
 }
 
 export function DashboardFeedCard({ item }: DashboardFeedCardProps) {
   const hasStatus = item.status != null;
   const isPresent = item.status === 'PRESENT';
-  const { heading } = splitDashboardCardTitle(item.title);
+  const heading = getDashboardCardHeading(item);
 
   return (
     <Card variant="outlined" elevation={0} sx={{ bgcolor: 'background.paper' }}>
@@ -101,7 +94,7 @@ export function DashboardFeedCard({ item }: DashboardFeedCardProps) {
             >
               {heading}
             </Typography>
-            {item.groupName ? (
+            {item.groupName && !hasStatus ? (
               <Typography
                 variant="body2"
                 color="text.secondary"

--- a/frontend/src/app/(main)/dashboard/DashboardFeedCard.tsx
+++ b/frontend/src/app/(main)/dashboard/DashboardFeedCard.tsx
@@ -27,10 +27,8 @@ function formatDashboardCardDate(value: string): string {
 }
 
 function getDashboardCardHeading(item: DashboardFeedItem): string {
-  if (item.status != null) {
-    return item.groupName
-      ? `Päevakokkuvõte - ${item.groupName}`
-      : 'Päevakokkuvõte';
+  if (item.groupName) {
+    return `Päevakokkuvõte - ${item.groupName}`;
   }
 
   return item.title;
@@ -94,13 +92,22 @@ export function DashboardFeedCard({ item }: DashboardFeedCardProps) {
             >
               {heading}
             </Typography>
+            {item.childName && hasStatus ? (
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 1.5, fontWeight: 500 }}
+              >
+                {item.childName}
+              </Typography>
+            ) : null}
             {item.groupName && !hasStatus ? (
               <Typography
                 variant="body2"
                 color="text.secondary"
                 sx={{ mb: 1.5, fontWeight: 500 }}
               >
-                {item.groupName}
+                {item.title}
               </Typography>
             ) : null}
             <Typography

--- a/frontend/src/app/(main)/dashboard/DashboardFeedCard.tsx
+++ b/frontend/src/app/(main)/dashboard/DashboardFeedCard.tsx
@@ -1,5 +1,13 @@
 import clsx from 'clsx';
-import { Box, Card, CardContent, Divider, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Divider,
+  Stack,
+  Typography,
+} from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import dayjs from 'dayjs';
@@ -7,6 +15,10 @@ import type { DashboardFeedItem } from './dashboard.types';
 
 type DashboardFeedCardProps = {
   item: DashboardFeedItem;
+  canManage?: boolean;
+  isDeleting?: boolean;
+  onEdit?: (item: DashboardFeedItem) => void;
+  onDelete?: (item: DashboardFeedItem) => void;
 };
 
 function formatDashboardCardDate(value: string): string {
@@ -26,7 +38,13 @@ function formatDashboardCardDate(value: string): string {
   }
 }
 
-export function DashboardFeedCard({ item }: DashboardFeedCardProps) {
+export function DashboardFeedCard({
+  item,
+  canManage = false,
+  isDeleting = false,
+  onEdit,
+  onDelete,
+}: DashboardFeedCardProps) {
   const hasStatus = item.status != null;
   const isPresent = item.status === 'PRESENT';
 
@@ -91,6 +109,31 @@ export function DashboardFeedCard({ item }: DashboardFeedCardProps) {
                 </Typography>
               </Box>
             </Box>
+          ) : null}
+
+          {canManage ? (
+            <Stack
+              direction="row"
+              justifyContent="flex-end"
+              spacing={1}
+              sx={{ mt: 2 }}
+            >
+              <Button
+                size="small"
+                variant="neutral"
+                onClick={() => onEdit?.(item)}
+              >
+                Muuda
+              </Button>
+              <Button
+                size="small"
+                variant="negative"
+                onClick={() => onDelete?.(item)}
+                disabled={isDeleting}
+              >
+                {isDeleting ? 'Kustutan...' : 'Kustuta'}
+              </Button>
+            </Stack>
           ) : null}
         </Box>
       </CardContent>

--- a/frontend/src/app/(main)/dashboard/dashboard.types.ts
+++ b/frontend/src/app/(main)/dashboard/dashboard.types.ts
@@ -6,6 +6,7 @@ export type DashboardFeedItem = {
   title: string;
   description: string;
   groupName?: string;
+  childName?: string;
   childId?: number;
   status?: AttendanceStatus;
 };

--- a/frontend/src/app/(main)/dashboard/dashboard.types.ts
+++ b/frontend/src/app/(main)/dashboard/dashboard.types.ts
@@ -5,8 +5,6 @@ export type DashboardFeedItem = {
   date: string;
   title: string;
   description: string;
-  groupName?: string;
-  childName?: string;
-  childId?: number;
   status?: AttendanceStatus;
+  childId?: number;
 };

--- a/frontend/src/app/(main)/dashboard/page.tsx
+++ b/frontend/src/app/(main)/dashboard/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import Button from '@mui/material/Button';
 import { useCallback, useEffect, useState } from 'react';
+import { CreatePostDialog } from '@/components/dashboard/CreatePostDialog';
 import { DashboardFeedCard } from '@/app/(main)/dashboard/DashboardFeedCard';
 import { PageTitle } from '@/components/PageTitle';
 import { showErrorToast } from '@/components/ErrorToast';
@@ -62,14 +64,17 @@ export default function DashboardPage() {
   const [dashboardFeedItems, setDashboardFeedItems] = useState<
     DashboardFeedItem[]
   >([]);
+  const [dashboardGroupId, setDashboardGroupId] = useState<number | null>(null);
   const [dashboardGroupName, setDashboardGroupName] = useState<string | null>(
     null
   );
   const [isLoading, setIsLoading] = useState(false);
+  const [isPostDialogOpen, setIsPostDialogOpen] = useState(false);
 
   const loadDashboardData = useCallback(async () => {
     if (!role) {
       setDashboardFeedItems([]);
+      setDashboardGroupId(null);
       setDashboardGroupName(null);
       return;
     }
@@ -86,6 +91,7 @@ export default function DashboardPage() {
 
         if (!selectedChild || !selectedGroupId) {
           setDashboardFeedItems([]);
+          setDashboardGroupId(null);
           setDashboardGroupName(selectedGroupName);
           return;
         }
@@ -111,6 +117,7 @@ export default function DashboardPage() {
         });
 
         setDashboardGroupName(selectedGroupName);
+        setDashboardGroupId(null);
         setDashboardFeedItems(
           mapPostsToDashboardItems(recentPosts, {
             childId: selectedChild.id,
@@ -132,11 +139,13 @@ export default function DashboardPage() {
 
         if (!teacherGroupId) {
           setDashboardFeedItems([]);
+          setDashboardGroupId(null);
           setDashboardGroupName(null);
           return;
         }
 
         const posts = await postService.getPostsByGroup(teacherGroupId);
+        setDashboardGroupId(teacherGroupId);
         setDashboardGroupName(groupById[teacherGroupId]?.name ?? null);
         setDashboardFeedItems(
           mapPostsToDashboardItems(Array.isArray(posts) ? posts : [], {})
@@ -145,9 +154,11 @@ export default function DashboardPage() {
       }
 
       setDashboardFeedItems([]);
+      setDashboardGroupId(null);
       setDashboardGroupName(null);
     } catch {
       setDashboardFeedItems([]);
+      setDashboardGroupId(null);
       setDashboardGroupName(null);
       showErrorToast('Avalehe andmete laadimine ebaõnnestus.');
     } finally {
@@ -173,20 +184,34 @@ export default function DashboardPage() {
     };
   }, [childLoading, loadDashboardData, role, roleLoading]);
 
+  const openPostDialog = () => {
+    setIsPostDialogOpen(true);
+  };
+
+  const closePostDialog = () => {
+    setIsPostDialogOpen(false);
+  };
+
   return (
     <div className="space-y-8">
-      <PageTitle>Avaleht</PageTitle>
-
       <section className="space-y-3">
-        <div className="space-y-1">
-          <h2 className="text-lg font-semibold text-ink">
-            {dashboardGroupName
-              ? `Päevakokkuvõtted - ${dashboardGroupName}`
-              : 'Päevakokkuvõtted'}
-          </h2>
-          <p className="text-sm text-mediumInk">
-            Rühma viimased teated kuvatakse siin.
-          </p>
+        <div className="flex flex-col gap-3 pb-5 mt-2 ml-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-ink">
+              {dashboardGroupName
+                ? `Päevakokkuvõtted - ${dashboardGroupName}`
+                : 'Päevakokkuvõtted'}
+            </h2>
+            <p className="text-sm text-mediumInk">
+              Rühma viimased postitused kuvatakse siin.
+            </p>
+          </div>
+
+          {role === USER_ROLE.TEACHER ? (
+            <Button variant="neutral" onClick={openPostDialog}>
+              Lisa uus
+            </Button>
+          ) : null}
         </div>
         {isLoading ? (
           <p className="text-sm text-mediumInk">Laadin avalehe andmeid...</p>
@@ -199,6 +224,13 @@ export default function DashboardPage() {
             ))}
           </div>
         )}
+
+        <CreatePostDialog
+          open={isPostDialogOpen}
+          groupId={dashboardGroupId}
+          onClose={closePostDialog}
+          onCreated={loadDashboardData}
+        />
       </section>
     </div>
   );

--- a/frontend/src/app/(main)/dashboard/page.tsx
+++ b/frontend/src/app/(main)/dashboard/page.tsx
@@ -70,6 +70,13 @@ export default function DashboardPage() {
   );
   const [isLoading, setIsLoading] = useState(false);
   const [isPostDialogOpen, setIsPostDialogOpen] = useState(false);
+  const [postDialogMode, setPostDialogMode] = useState<'create' | 'edit'>(
+    'create'
+  );
+  const [editingPost, setEditingPost] = useState<DashboardFeedItem | null>(
+    null
+  );
+  const [deletingPostId, setDeletingPostId] = useState<number | null>(null);
 
   const loadDashboardData = useCallback(async () => {
     if (!role) {
@@ -185,11 +192,39 @@ export default function DashboardPage() {
   }, [childLoading, loadDashboardData, role, roleLoading]);
 
   const openPostDialog = () => {
+    setPostDialogMode('create');
+    setEditingPost(null);
+    setIsPostDialogOpen(true);
+  };
+
+  const openEditPostDialog = (item: DashboardFeedItem) => {
+    setPostDialogMode('edit');
+    setEditingPost(item);
     setIsPostDialogOpen(true);
   };
 
   const closePostDialog = () => {
     setIsPostDialogOpen(false);
+    setPostDialogMode('create');
+    setEditingPost(null);
+  };
+
+  const handleDeletePost = async (item: DashboardFeedItem) => {
+    const shouldDelete = window.confirm(`Kustuta postitus "${item.title}"?`);
+    if (!shouldDelete) {
+      return;
+    }
+
+    setDeletingPostId(item.id);
+    try {
+      await postService.deletePost(item.id);
+      await loadDashboardData();
+    } catch (error) {
+      const err = error as Error;
+      showErrorToast(err.message || 'Postituse kustutamine ebaõnnestus.');
+    } finally {
+      setDeletingPostId(null);
+    }
   };
 
   return (
@@ -220,14 +255,25 @@ export default function DashboardPage() {
         ) : (
           <div className="space-y-6">
             {dashboardFeedItems.map((item) => (
-              <DashboardFeedCard key={item.id} item={item} />
+              <DashboardFeedCard
+                key={item.id}
+                item={item}
+                canManage={role === USER_ROLE.TEACHER}
+                isDeleting={deletingPostId === item.id}
+                onEdit={openEditPostDialog}
+                onDelete={handleDeletePost}
+              />
             ))}
           </div>
         )}
 
         <CreatePostDialog
           open={isPostDialogOpen}
+          mode={postDialogMode}
           groupId={dashboardGroupId}
+          postId={editingPost?.id ?? null}
+          initialTitle={editingPost?.title ?? ''}
+          initialMessage={editingPost?.description ?? ''}
           onClose={closePostDialog}
           onCreated={loadDashboardData}
         />

--- a/frontend/src/app/(main)/dashboard/page.tsx
+++ b/frontend/src/app/(main)/dashboard/page.tsx
@@ -37,15 +37,18 @@ function mapPostsToDashboardItems(
   options?: {
     childId?: number;
     statusByDate?: Record<string, DashboardFeedItem['status']>;
+    defaultStatus?: DashboardFeedItem['status'];
   }
 ): DashboardFeedItem[] {
+  const defaultStatus = options?.defaultStatus ?? 'PRESENT';
+
   return getRecentPosts(posts).map((post) => ({
     id: post.id,
     date: post.createdAt,
     title: post.title,
     description: post.message,
     childId: options?.childId,
-    status: options?.statusByDate?.[toDateKey(post.createdAt)],
+    status: options?.statusByDate?.[toDateKey(post.createdAt)] ?? defaultStatus,
   }));
 }
 
@@ -138,6 +141,7 @@ export default function DashboardPage() {
         setDashboardFeedItems(
           mapPostsToDashboardItems(recentPosts, {
             childId: selectedChild.id,
+            defaultStatus: 'PRESENT',
             statusByDate: mapAbsenceStatusByDate(
               Array.isArray(absences) ? absences : []
             ),

--- a/frontend/src/app/(main)/dashboard/page.tsx
+++ b/frontend/src/app/(main)/dashboard/page.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select, { type SelectChangeEvent } from '@mui/material/Select';
 import { useCallback, useEffect, useState } from 'react';
 import { CreatePostDialog } from '@/components/dashboard/CreatePostDialog';
 import { DashboardFeedCard } from '@/app/(main)/dashboard/DashboardFeedCard';
@@ -64,11 +68,15 @@ export default function DashboardPage() {
   const [dashboardFeedItems, setDashboardFeedItems] = useState<
     DashboardFeedItem[]
   >([]);
+  const [availableGroups, setAvailableGroups] = useState<Group[]>([]);
   const [dashboardGroupId, setDashboardGroupId] = useState<number | null>(null);
   const [dashboardGroupName, setDashboardGroupName] = useState<string | null>(
     null
   );
   const [isLoading, setIsLoading] = useState(false);
+  const [selectedManagedGroupId, setSelectedManagedGroupId] = useState<number | null>(
+    null
+  );
   const [isPostDialogOpen, setIsPostDialogOpen] = useState(false);
   const [postDialogMode, setPostDialogMode] = useState<'create' | 'edit'>(
     'create'
@@ -81,6 +89,7 @@ export default function DashboardPage() {
   const loadDashboardData = useCallback(async () => {
     if (!role) {
       setDashboardFeedItems([]);
+      setAvailableGroups([]);
       setDashboardGroupId(null);
       setDashboardGroupName(null);
       return;
@@ -90,6 +99,7 @@ export default function DashboardPage() {
 
     try {
       if (role === USER_ROLE.PARENT) {
+        setAvailableGroups([]);
         const selectedChild = children.find(
           (child) => child.id === selectedChildId
         );
@@ -136,24 +146,56 @@ export default function DashboardPage() {
         return;
       }
 
-      if (role === USER_ROLE.TEACHER) {
+      if (role === USER_ROLE.TEACHER || role === USER_ROLE.ADMIN) {
         const groups = await groupService.getGroups();
         const groupById = Object.fromEntries(
           groups.map((group) => [group.id, group])
         ) as Record<number, Group>;
-        const profile = await authService.getProfile();
-        const teacherGroupId = profile.groupIds?.[0] ?? null;
 
-        if (!teacherGroupId) {
+        let resolvedGroupId: number | null = null;
+        let manageableGroups = groups;
+
+        if (role === USER_ROLE.TEACHER) {
+          const profile = await authService.getProfile();
+          const teacherGroupIds = profile.groupIds ?? [];
+          manageableGroups = groups.filter((group) =>
+            teacherGroupIds.includes(group.id)
+          );
+          const nextTeacherGroupId =
+            selectedManagedGroupId &&
+            manageableGroups.some((group) => group.id === selectedManagedGroupId)
+              ? selectedManagedGroupId
+              : manageableGroups[0]?.id ?? null;
+
+          resolvedGroupId = nextTeacherGroupId;
+          if (nextTeacherGroupId !== selectedManagedGroupId) {
+            setSelectedManagedGroupId(nextTeacherGroupId);
+          }
+        } else {
+          const nextAdminGroupId =
+            selectedManagedGroupId &&
+            manageableGroups.some((group) => group.id === selectedManagedGroupId)
+              ? selectedManagedGroupId
+              : manageableGroups[0]?.id ?? null;
+
+          resolvedGroupId = nextAdminGroupId;
+          if (nextAdminGroupId !== selectedManagedGroupId) {
+            setSelectedManagedGroupId(nextAdminGroupId);
+          }
+        }
+
+        setAvailableGroups(manageableGroups);
+
+        if (!resolvedGroupId) {
           setDashboardFeedItems([]);
           setDashboardGroupId(null);
           setDashboardGroupName(null);
           return;
         }
 
-        const posts = await postService.getPostsByGroup(teacherGroupId);
-        setDashboardGroupId(teacherGroupId);
-        setDashboardGroupName(groupById[teacherGroupId]?.name ?? null);
+        const posts = await postService.getPostsByGroup(resolvedGroupId);
+        setDashboardGroupId(resolvedGroupId);
+        setDashboardGroupName(groupById[resolvedGroupId]?.name ?? null);
         setDashboardFeedItems(
           mapPostsToDashboardItems(Array.isArray(posts) ? posts : [], {})
         );
@@ -171,7 +213,7 @@ export default function DashboardPage() {
     } finally {
       setIsLoading(false);
     }
-  }, [children, role, selectedChildId]);
+  }, [children, role, selectedChildId, selectedManagedGroupId]);
 
   useEffect(() => {
     if (roleLoading) {
@@ -190,6 +232,11 @@ export default function DashboardPage() {
       window.clearTimeout(timerId);
     };
   }, [childLoading, loadDashboardData, role, roleLoading]);
+
+  const handleManagedGroupChange = (event: SelectChangeEvent<string>) => {
+    const nextGroupId = Number(event.target.value);
+    setSelectedManagedGroupId(Number.isNaN(nextGroupId) ? null : nextGroupId);
+  };
 
   const openPostDialog = () => {
     setPostDialogMode('create');
@@ -238,27 +285,58 @@ export default function DashboardPage() {
                 : 'Päevakokkuvõtted'}
             </h2>
             <p className="text-sm text-mediumInk">
-              Rühma viimased postitused kuvatakse siin.
+              {role === USER_ROLE.ADMIN || role === USER_ROLE.TEACHER
+                ? 'Vali rühm ja halda selle postitusi.'
+                : 'Rühma viimased postitused kuvatakse siin.'}
             </p>
           </div>
 
-          {role === USER_ROLE.TEACHER ? (
-            <Button variant="neutral" onClick={openPostDialog}>
-              Lisa uus
-            </Button>
-          ) : null}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            {role === USER_ROLE.ADMIN ||
+            (role === USER_ROLE.TEACHER && availableGroups.length > 1) ? (
+              <FormControl size="small" sx={{ minWidth: 220 }}>
+                <InputLabel id="dashboard-group-select-label">Rühm</InputLabel>
+                <Select
+                  labelId="dashboard-group-select-label"
+                  value={selectedManagedGroupId != null ? String(selectedManagedGroupId) : ''}
+                  label="Rühm"
+                  onChange={handleManagedGroupChange}
+                  disabled={availableGroups.length === 0}
+                >
+                  {availableGroups.map((group) => (
+                    <MenuItem key={group.id} value={String(group.id)}>
+                      {group.name || `Rühm ${group.id}`}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            ) : null}
+
+            {role === USER_ROLE.TEACHER || role === USER_ROLE.ADMIN ? (
+              <Button variant="neutral" onClick={openPostDialog}>
+                Lisa uus
+              </Button>
+            ) : null}
+          </div>
         </div>
         {isLoading ? (
           <p className="text-sm text-mediumInk">Laadin avalehe andmeid...</p>
         ) : dashboardFeedItems.length === 0 ? (
-          <p className="text-sm text-mediumInk">Päevakokkuvõtteid ei leitud.</p>
+          <p className="text-sm text-mediumInk">
+            {(role === USER_ROLE.ADMIN || role === USER_ROLE.TEACHER) &&
+            availableGroups.length === 0
+              ? 'Rühmi ei leitud.'
+              : 'Päevakokkuvõtteid ei leitud.'}
+          </p>
         ) : (
           <div className="space-y-6">
             {dashboardFeedItems.map((item) => (
               <DashboardFeedCard
                 key={item.id}
                 item={item}
-                canManage={role === USER_ROLE.TEACHER}
+                canManage={
+                  role === USER_ROLE.TEACHER || role === USER_ROLE.ADMIN
+                }
                 isDeleting={deletingPostId === item.id}
                 onEdit={openEditPostDialog}
                 onDelete={handleDeletePost}

--- a/frontend/src/app/(main)/dashboard/page.tsx
+++ b/frontend/src/app/(main)/dashboard/page.tsx
@@ -10,7 +10,6 @@ import { CreatePostDialog } from '@/components/dashboard/CreatePostDialog';
 import { DashboardFeedCard } from '@/app/(main)/dashboard/DashboardFeedCard';
 import { PageTitle } from '@/components/PageTitle';
 import { showErrorToast } from '@/components/ErrorToast';
-import authService from '@/services/auth.service';
 import { useChildSelection } from '@/context/ChildSelectionContext';
 import { useUserRole } from '@/context/UserRoleContext';
 import calendarService from '@/services/calendar.service';
@@ -65,6 +64,7 @@ export default function DashboardPage() {
     selectedChildId,
     loading: childLoading,
   } = useChildSelection();
+  const canManage = role === USER_ROLE.TEACHER || role === USER_ROLE.ADMIN;
   const [dashboardFeedItems, setDashboardFeedItems] = useState<
     DashboardFeedItem[]
   >([]);
@@ -74,9 +74,9 @@ export default function DashboardPage() {
     null
   );
   const [isLoading, setIsLoading] = useState(false);
-  const [selectedManagedGroupId, setSelectedManagedGroupId] = useState<number | null>(
-    null
-  );
+  const [selectedManagedGroupId, setSelectedManagedGroupId] = useState<
+    number | null
+  >(null);
   const [isPostDialogOpen, setIsPostDialogOpen] = useState(false);
   const [postDialogMode, setPostDialogMode] = useState<'create' | 'edit'>(
     'create'
@@ -146,56 +146,33 @@ export default function DashboardPage() {
         return;
       }
 
-      if (role === USER_ROLE.TEACHER || role === USER_ROLE.ADMIN) {
+      if (canManage) {
         const groups = await groupService.getGroups();
-        const groupById = Object.fromEntries(
-          groups.map((group) => [group.id, group])
-        ) as Record<number, Group>;
+        // Keep the current group if it is still available; otherwise fall back to the first available group.
+        const activeGroupId =
+          selectedManagedGroupId &&
+          groups.some((group) => group.id === selectedManagedGroupId)
+            ? selectedManagedGroupId
+            : (groups[0]?.id ?? null);
+        const activeGroup =
+          groups.find((group) => group.id === activeGroupId) ?? null;
 
-        let resolvedGroupId: number | null = null;
-        let manageableGroups = groups;
+        setAvailableGroups(groups);
 
-        if (role === USER_ROLE.TEACHER) {
-          const profile = await authService.getProfile();
-          const teacherGroupIds = profile.groupIds ?? [];
-          manageableGroups = groups.filter((group) =>
-            teacherGroupIds.includes(group.id)
-          );
-          const nextTeacherGroupId =
-            selectedManagedGroupId &&
-            manageableGroups.some((group) => group.id === selectedManagedGroupId)
-              ? selectedManagedGroupId
-              : manageableGroups[0]?.id ?? null;
-
-          resolvedGroupId = nextTeacherGroupId;
-          if (nextTeacherGroupId !== selectedManagedGroupId) {
-            setSelectedManagedGroupId(nextTeacherGroupId);
-          }
-        } else {
-          const nextAdminGroupId =
-            selectedManagedGroupId &&
-            manageableGroups.some((group) => group.id === selectedManagedGroupId)
-              ? selectedManagedGroupId
-              : manageableGroups[0]?.id ?? null;
-
-          resolvedGroupId = nextAdminGroupId;
-          if (nextAdminGroupId !== selectedManagedGroupId) {
-            setSelectedManagedGroupId(nextAdminGroupId);
-          }
+        if (activeGroupId !== selectedManagedGroupId) {
+          setSelectedManagedGroupId(activeGroupId);
         }
 
-        setAvailableGroups(manageableGroups);
-
-        if (!resolvedGroupId) {
+        if (!activeGroupId) {
           setDashboardFeedItems([]);
           setDashboardGroupId(null);
           setDashboardGroupName(null);
           return;
         }
 
-        const posts = await postService.getPostsByGroup(resolvedGroupId);
-        setDashboardGroupId(resolvedGroupId);
-        setDashboardGroupName(groupById[resolvedGroupId]?.name ?? null);
+        const posts = await postService.getPostsByGroup(activeGroupId);
+        setDashboardGroupId(activeGroupId);
+        setDashboardGroupName(activeGroup?.name ?? null);
         setDashboardFeedItems(
           mapPostsToDashboardItems(Array.isArray(posts) ? posts : [], {})
         );
@@ -213,7 +190,7 @@ export default function DashboardPage() {
     } finally {
       setIsLoading(false);
     }
-  }, [children, role, selectedChildId, selectedManagedGroupId]);
+  }, [canManage, children, role, selectedChildId, selectedManagedGroupId]);
 
   useEffect(() => {
     if (roleLoading) {
@@ -285,7 +262,7 @@ export default function DashboardPage() {
                 : 'Päevakokkuvõtted'}
             </h2>
             <p className="text-sm text-mediumInk">
-              {role === USER_ROLE.ADMIN || role === USER_ROLE.TEACHER
+              {canManage
                 ? 'Vali rühm ja halda selle postitusi.'
                 : 'Rühma viimased postitused kuvatakse siin.'}
             </p>
@@ -298,7 +275,11 @@ export default function DashboardPage() {
                 <InputLabel id="dashboard-group-select-label">Rühm</InputLabel>
                 <Select
                   labelId="dashboard-group-select-label"
-                  value={selectedManagedGroupId != null ? String(selectedManagedGroupId) : ''}
+                  value={
+                    selectedManagedGroupId != null
+                      ? String(selectedManagedGroupId)
+                      : ''
+                  }
                   label="Rühm"
                   onChange={handleManagedGroupChange}
                   disabled={availableGroups.length === 0}
@@ -312,7 +293,7 @@ export default function DashboardPage() {
               </FormControl>
             ) : null}
 
-            {role === USER_ROLE.TEACHER || role === USER_ROLE.ADMIN ? (
+            {canManage ? (
               <Button variant="neutral" onClick={openPostDialog}>
                 Lisa uus
               </Button>
@@ -323,8 +304,7 @@ export default function DashboardPage() {
           <p className="text-sm text-mediumInk">Laadin avalehe andmeid...</p>
         ) : dashboardFeedItems.length === 0 ? (
           <p className="text-sm text-mediumInk">
-            {(role === USER_ROLE.ADMIN || role === USER_ROLE.TEACHER) &&
-            availableGroups.length === 0
+            {canManage && availableGroups.length === 0
               ? 'Rühmi ei leitud.'
               : 'Päevakokkuvõtteid ei leitud.'}
           </p>
@@ -334,9 +314,7 @@ export default function DashboardPage() {
               <DashboardFeedCard
                 key={item.id}
                 item={item}
-                canManage={
-                  role === USER_ROLE.TEACHER || role === USER_ROLE.ADMIN
-                }
+                canManage={canManage}
                 isDeleting={deletingPostId === item.id}
                 onEdit={openEditPostDialog}
                 onDelete={handleDeletePost}

--- a/frontend/src/app/(main)/dashboard/page.tsx
+++ b/frontend/src/app/(main)/dashboard/page.tsx
@@ -11,62 +11,45 @@ import calendarService from '@/services/calendar.service';
 import groupService from '@/services/group.service';
 import postService from '@/services/post.service';
 import type { AbsenceEntry, Group, Post } from '@/types';
-import { ATTENDANCE_STATUS, USER_ROLE } from '@/types/enums';
+import { USER_ROLE } from '@/types/enums';
 import dayjs from 'dayjs';
 
 import type { DashboardFeedItem } from './dashboard.types';
 
 const DASHBOARD_ITEMS_DISPLAYED = 10;
 
-function mapAbsencesToDashboardItems(
-  absences: AbsenceEntry[],
-  groupName?: string | null
-): DashboardFeedItem[] {
-  return [...absences]
-    .sort(
-      (left, right) => dayjs(right.date).valueOf() - dayjs(left.date).valueOf()
-    )
-    .slice(0, DASHBOARD_ITEMS_DISPLAYED)
-    .map((entry) => {
-      const name = [entry.firstName, entry.lastName]
-        .filter(Boolean)
-        .join(' ')
-        .trim();
+function toDateKey(value: string): string {
+  const match = value.match(/^\d{4}-\d{2}-\d{2}/);
+  return match ? match[0] : dayjs(value).format('YYYY-MM-DD');
+}
 
-      return {
-        id: entry.id,
-        date: entry.date,
-        title: `Summary - ${name || 'Attendance'}`,
-        description:
-          entry.note?.trim() ||
-          (entry.status === ATTENDANCE_STATUS.ABSENT
-            ? 'Puudumise märge puudub.'
-            : 'Kohaloleku märge puudub.'),
-        groupName: groupName ?? 'Bumblebees',
-        childName: name,
-        childId: entry.childId,
-        status: entry.status,
-      };
-    });
+function getRecentPosts(posts: Post[]): Post[] {
+  return posts.slice(0, DASHBOARD_ITEMS_DISPLAYED);
 }
 
 function mapPostsToDashboardItems(
   posts: Post[],
-  groupById: Record<number, Group>
+  options?: {
+    childId?: number;
+    statusByDate?: Record<string, DashboardFeedItem['status']>;
+  }
 ): DashboardFeedItem[] {
-  return [...posts]
-    .sort(
-      (left, right) =>
-        dayjs(right.createdAt).valueOf() - dayjs(left.createdAt).valueOf()
-    )
-    .slice(0, DASHBOARD_ITEMS_DISPLAYED)
-    .map((post) => ({
-      id: post.id,
-      date: post.createdAt,
-      title: post.title,
-      description: post.message,
-      groupName: groupById[post.groupId]?.name ?? 'Bumblebees',
-    }));
+  return getRecentPosts(posts).map((post) => ({
+    id: post.id,
+    date: post.createdAt,
+    title: post.title,
+    description: post.message,
+    childId: options?.childId,
+    status: options?.statusByDate?.[toDateKey(post.createdAt)],
+  }));
+}
+
+function mapAbsenceStatusByDate(
+  absences: AbsenceEntry[]
+): Record<string, DashboardFeedItem['status']> {
+  return Object.fromEntries(
+    absences.map((entry) => [toDateKey(entry.date), entry.status])
+  );
 }
 
 export default function DashboardPage() {
@@ -79,69 +62,93 @@ export default function DashboardPage() {
   const [dashboardFeedItems, setDashboardFeedItems] = useState<
     DashboardFeedItem[]
   >([]);
+  const [dashboardGroupName, setDashboardGroupName] = useState<string | null>(
+    null
+  );
   const [isLoading, setIsLoading] = useState(false);
 
   const loadDashboardData = useCallback(async () => {
     if (!role) {
       setDashboardFeedItems([]);
+      setDashboardGroupName(null);
       return;
     }
-
-    const to = dayjs().format('YYYY-MM-DD');
-    const from = dayjs()
-      .subtract(DASHBOARD_ITEMS_DISPLAYED, 'day')
-      .format('YYYY-MM-DD');
 
     setIsLoading(true);
 
     try {
       if (role === USER_ROLE.PARENT) {
-        const absenceEntries = selectedChildId
-          ? await calendarService.getAbsencesByChild({
-              childId: selectedChildId,
-              from,
-              to,
-            })
-          : [];
+        const selectedChild = children.find(
+          (child) => child.id === selectedChildId
+        );
+        const selectedGroupId = selectedChild?.groupId ?? null;
+        const selectedGroupName = selectedChild?.groupName ?? null;
 
-        const selectedGroupName =
-          children.find((child) => child.id === selectedChildId)?.groupName ??
-          null;
+        if (!selectedChild || !selectedGroupId) {
+          setDashboardFeedItems([]);
+          setDashboardGroupName(selectedGroupName);
+          return;
+        }
 
+        const posts = await postService.getPostsByGroup(selectedGroupId);
+        const recentPosts = getRecentPosts(Array.isArray(posts) ? posts : []);
+        const absenceFrom =
+          recentPosts.length > 0
+            ? dayjs(recentPosts[recentPosts.length - 1].createdAt).format(
+                'YYYY-MM-DD'
+              )
+            : dayjs()
+                .subtract(DASHBOARD_ITEMS_DISPLAYED, 'day')
+                .format('YYYY-MM-DD');
+        const absenceTo =
+          recentPosts.length > 0
+            ? dayjs(recentPosts[0].createdAt).format('YYYY-MM-DD')
+            : dayjs().format('YYYY-MM-DD');
+        const absences = await calendarService.getAbsencesByChild({
+          childId: selectedChild.id,
+          from: absenceFrom,
+          to: absenceTo,
+        });
+
+        setDashboardGroupName(selectedGroupName);
         setDashboardFeedItems(
-          mapAbsencesToDashboardItems(
-            Array.isArray(absenceEntries) ? absenceEntries : [],
-            selectedGroupName
-          )
+          mapPostsToDashboardItems(recentPosts, {
+            childId: selectedChild.id,
+            statusByDate: mapAbsenceStatusByDate(
+              Array.isArray(absences) ? absences : []
+            ),
+          })
         );
         return;
       }
 
-      const groups = await groupService.getGroups();
-      const groupById = Object.fromEntries(
-        groups.map((group) => [group.id, group])
-      ) as Record<number, Group>;
-
       if (role === USER_ROLE.TEACHER) {
+        const groups = await groupService.getGroups();
+        const groupById = Object.fromEntries(
+          groups.map((group) => [group.id, group])
+        ) as Record<number, Group>;
         const profile = await authService.getProfile();
-        // const teacherGroupId = profile.groupIds?.[0] ?? null;
-        const teacherGroupId = 1;
+        const teacherGroupId = profile.groupIds?.[0] ?? null;
 
         if (!teacherGroupId) {
           setDashboardFeedItems([]);
+          setDashboardGroupName(null);
           return;
         }
 
         const posts = await postService.getPostsByGroup(teacherGroupId);
+        setDashboardGroupName(groupById[teacherGroupId]?.name ?? null);
         setDashboardFeedItems(
-          mapPostsToDashboardItems(Array.isArray(posts) ? posts : [], groupById)
+          mapPostsToDashboardItems(Array.isArray(posts) ? posts : [], {})
         );
         return;
       }
 
       setDashboardFeedItems([]);
+      setDashboardGroupName(null);
     } catch {
       setDashboardFeedItems([]);
+      setDashboardGroupName(null);
       showErrorToast('Avalehe andmete laadimine ebaõnnestus.');
     } finally {
       setIsLoading(false);
@@ -172,9 +179,13 @@ export default function DashboardPage() {
 
       <section className="space-y-3">
         <div className="space-y-1">
-          <h2 className="text-lg font-semibold text-ink">Päevakokkuvõtted</h2>
+          <h2 className="text-lg font-semibold text-ink">
+            {dashboardGroupName
+              ? `Päevakokkuvõtted - ${dashboardGroupName}`
+              : 'Päevakokkuvõtted'}
+          </h2>
           <p className="text-sm text-mediumInk">
-            Kohaloleku ja puudumiste viimased sissekanded kuvatakse siin.
+            Rühma viimased teated kuvatakse siin.
           </p>
         </div>
         {isLoading ? (

--- a/frontend/src/app/(main)/dashboard/page.tsx
+++ b/frontend/src/app/(main)/dashboard/page.tsx
@@ -80,8 +80,8 @@ export default function DashboardPage() {
       return;
     }
 
-    const from = dayjs().startOf('month').format('YYYY-MM-DD');
-    const to = dayjs().endOf('month').format('YYYY-MM-DD');
+    const to = dayjs().format('YYYY-MM-DD');
+    const from = dayjs().subtract(30, 'day').format('YYYY-MM-DD');
 
     setIsLoading(true);
 
@@ -95,10 +95,14 @@ export default function DashboardPage() {
             })
           : [];
 
+        const groups = selectedGroupId ? await groupService.getGroups() : [];
+        const selectedGroupName =
+          groups.find((group) => group.id === selectedGroupId)?.name ?? null;
+
         setDashboardFeedItems(
           mapAbsencesToDashboardItems(
             Array.isArray(absenceEntries) ? absenceEntries : [],
-            null
+            selectedGroupName
           )
         );
         return;
@@ -133,7 +137,7 @@ export default function DashboardPage() {
     } finally {
       setIsLoading(false);
     }
-  }, [role, selectedChildId]);
+  }, [role, selectedChildId, selectedGroupId]);
 
   useEffect(() => {
     if (roleLoading) {

--- a/frontend/src/app/(main)/dashboard/page.tsx
+++ b/frontend/src/app/(main)/dashboard/page.tsx
@@ -16,6 +16,8 @@ import dayjs from 'dayjs';
 
 import type { DashboardFeedItem } from './dashboard.types';
 
+const DASHBOARD_ITEMS_DISPLAYED = 10;
+
 function mapAbsencesToDashboardItems(
   absences: AbsenceEntry[],
   groupName?: string | null
@@ -24,7 +26,7 @@ function mapAbsencesToDashboardItems(
     .sort(
       (left, right) => dayjs(right.date).valueOf() - dayjs(left.date).valueOf()
     )
-    .slice(0, 5)
+    .slice(0, DASHBOARD_ITEMS_DISPLAYED)
     .map((entry) => {
       const name = [entry.firstName, entry.lastName]
         .filter(Boolean)
@@ -41,6 +43,7 @@ function mapAbsencesToDashboardItems(
             ? 'Puudumise märge puudub.'
             : 'Kohaloleku märge puudub.'),
         groupName: groupName ?? 'Bumblebees',
+        childName: name,
         childId: entry.childId,
         status: entry.status,
       };
@@ -56,7 +59,7 @@ function mapPostsToDashboardItems(
       (left, right) =>
         dayjs(right.createdAt).valueOf() - dayjs(left.createdAt).valueOf()
     )
-    .slice(0, 5)
+    .slice(0, DASHBOARD_ITEMS_DISPLAYED)
     .map((post) => ({
       id: post.id,
       date: post.createdAt,
@@ -68,7 +71,11 @@ function mapPostsToDashboardItems(
 
 export default function DashboardPage() {
   const { role, loading: roleLoading } = useUserRole();
-  const { selectedChildId, selectedGroupId, loading: childLoading } = useChildSelection();
+  const {
+    children,
+    selectedChildId,
+    loading: childLoading,
+  } = useChildSelection();
   const [dashboardFeedItems, setDashboardFeedItems] = useState<
     DashboardFeedItem[]
   >([]);
@@ -81,7 +88,9 @@ export default function DashboardPage() {
     }
 
     const to = dayjs().format('YYYY-MM-DD');
-    const from = dayjs().subtract(30, 'day').format('YYYY-MM-DD');
+    const from = dayjs()
+      .subtract(DASHBOARD_ITEMS_DISPLAYED, 'day')
+      .format('YYYY-MM-DD');
 
     setIsLoading(true);
 
@@ -95,9 +104,9 @@ export default function DashboardPage() {
             })
           : [];
 
-        const groups = selectedGroupId ? await groupService.getGroups() : [];
         const selectedGroupName =
-          groups.find((group) => group.id === selectedGroupId)?.name ?? null;
+          children.find((child) => child.id === selectedChildId)?.groupName ??
+          null;
 
         setDashboardFeedItems(
           mapAbsencesToDashboardItems(
@@ -137,7 +146,7 @@ export default function DashboardPage() {
     } finally {
       setIsLoading(false);
     }
-  }, [role, selectedChildId, selectedGroupId]);
+  }, [children, role, selectedChildId]);
 
   useEffect(() => {
     if (roleLoading) {

--- a/frontend/src/components/dashboard/CreatePostDialog.tsx
+++ b/frontend/src/components/dashboard/CreatePostDialog.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useState } from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
+import { showErrorToast, showSuccessToast } from '@/components/ErrorToast';
+import postService from '@/services/post.service';
+
+type CreatePostDialogProps = {
+  open: boolean;
+  groupId: number | null;
+  onClose: () => void;
+  onCreated: () => void | Promise<void>;
+};
+
+export function CreatePostDialog({
+  open,
+  groupId,
+  onClose,
+  onCreated,
+}: CreatePostDialogProps) {
+  const [title, setTitle] = useState('');
+  const [message, setMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setTitle('');
+    setMessage('');
+  }, [open]);
+
+  const canSubmit = useMemo(() => {
+    if (isSubmitting || !groupId) {
+      return false;
+    }
+
+    return Boolean(title.trim() && message.trim());
+  }, [groupId, isSubmitting, message, title]);
+
+  const handleSubmit = async () => {
+    if (!groupId) {
+      showErrorToast('Rühma ei leitud.');
+      return;
+    }
+
+    if (!title.trim()) {
+      showErrorToast('Palun sisesta pealkiri.');
+      return;
+    }
+
+    if (!message.trim()) {
+      showErrorToast('Palun sisesta sisu.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await postService.createPost(title.trim(), message.trim(), groupId);
+      await onCreated();
+      showSuccessToast('Postitus loodud');
+      onClose();
+    } catch (error) {
+      const err = error as Error;
+      showErrorToast(err.message || 'Postituse loomine ebaõnnestus.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Lisa uus postitus</DialogTitle>
+      <DialogContent sx={{ display: 'grid', gap: 2, pt: '26px !important' }}>
+        <TextField
+          label="Pealkiri"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          InputLabelProps={{ shrink: true }}
+          fullWidth
+        />
+
+        <TextField
+          label="Sisu"
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          InputLabelProps={{ shrink: true }}
+          fullWidth
+          multiline
+          minRows={5}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button variant="neutral" onClick={onClose}>
+          Tühista
+        </Button>
+        <Button variant="info" onClick={handleSubmit} disabled={!canSubmit}>
+          {isSubmitting ? 'Salvestamine...' : 'Salvesta'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/dashboard/CreatePostDialog.tsx
+++ b/frontend/src/components/dashboard/CreatePostDialog.tsx
@@ -8,16 +8,26 @@ import TextField from '@mui/material/TextField';
 import { showErrorToast, showSuccessToast } from '@/components/ErrorToast';
 import postService from '@/services/post.service';
 
+type PostDialogMode = 'create' | 'edit';
+
 type CreatePostDialogProps = {
   open: boolean;
+  mode: PostDialogMode;
   groupId: number | null;
+  postId?: number | null;
+  initialTitle?: string;
+  initialMessage?: string;
   onClose: () => void;
   onCreated: () => void | Promise<void>;
 };
 
 export function CreatePostDialog({
   open,
+  mode,
   groupId,
+  postId,
+  initialTitle = '',
+  initialMessage = '',
   onClose,
   onCreated,
 }: CreatePostDialogProps) {
@@ -30,9 +40,9 @@ export function CreatePostDialog({
       return;
     }
 
-    setTitle('');
-    setMessage('');
-  }, [open]);
+    setTitle(initialTitle);
+    setMessage(initialMessage);
+  }, [initialMessage, initialTitle, open]);
 
   const canSubmit = useMemo(() => {
     if (isSubmitting || !groupId) {
@@ -58,15 +68,32 @@ export function CreatePostDialog({
       return;
     }
 
+    if (mode === 'edit' && !postId) {
+      showErrorToast('Postitust ei leitud.');
+      return;
+    }
+
     setIsSubmitting(true);
     try {
-      await postService.createPost(title.trim(), message.trim(), groupId);
+      if (mode === 'edit' && postId) {
+        await postService.updatePost(postId, title.trim(), message.trim());
+      } else {
+        await postService.createPost(title.trim(), message.trim(), groupId);
+      }
+
       await onCreated();
-      showSuccessToast('Postitus loodud');
+      showSuccessToast(
+        mode === 'edit' ? 'Postitus uuendatud' : 'Postitus loodud'
+      );
       onClose();
     } catch (error) {
       const err = error as Error;
-      showErrorToast(err.message || 'Postituse loomine ebaõnnestus.');
+      showErrorToast(
+        err.message ||
+          (mode === 'edit'
+            ? 'Postituse uuendamine ebaõnnestus.'
+            : 'Postituse loomine ebaõnnestus.')
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -74,7 +101,9 @@ export function CreatePostDialog({
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-      <DialogTitle>Lisa uus postitus</DialogTitle>
+      <DialogTitle>
+        {mode === 'edit' ? 'Muuda postitust' : 'Lisa uus postitus'}
+      </DialogTitle>
       <DialogContent sx={{ display: 'grid', gap: 2, pt: '26px !important' }}>
         <TextField
           label="Pealkiri"
@@ -99,7 +128,11 @@ export function CreatePostDialog({
           Tühista
         </Button>
         <Button variant="info" onClick={handleSubmit} disabled={!canSubmit}>
-          {isSubmitting ? 'Salvestamine...' : 'Salvesta'}
+          {isSubmitting
+            ? 'Salvestamine...'
+            : mode === 'edit'
+              ? 'Uuenda'
+              : 'Salvesta'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -44,6 +44,8 @@ export const apiPaths = {
   posts: {
     create: '/posts',
     group: (groupId: number) => `/posts/group/${groupId}`,
+    update: (postId: number) => `/posts/${postId}`,
+    remove: (postId: number) => `/posts/${postId}`,
   },
   absences: {
     childByRange: ({

--- a/frontend/src/services/post.service.ts
+++ b/frontend/src/services/post.service.ts
@@ -8,7 +8,7 @@ import {
   unwrapData,
 } from '@/services/http.service';
 
-const USE_DUMMY_POST_DATA = true; // Only for demo
+const USE_DUMMY_POST_DATA = false; // Only for demo
 
 class PostService {
   async getPostsByGroup(groupId: number): Promise<Post[]> {

--- a/frontend/src/services/post.service.ts
+++ b/frontend/src/services/post.service.ts
@@ -49,6 +49,46 @@ class PostService {
     return unwrapData<Post>(data);
   }
 
+  async updatePost(
+    postId: number,
+    title: string,
+    message: string
+  ): Promise<Post> {
+    const response = await fetchWithAuth(
+      apiUrl(apiPaths.posts.update(postId)),
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, content: message }),
+      }
+    );
+    const data = await parseJson(response);
+
+    if (!response.ok) {
+      throw new Error(
+        extractErrorMessage(data, `Failed to update post (${response.status})`)
+      );
+    }
+
+    return unwrapData<Post>(data);
+  }
+
+  async deletePost(postId: number): Promise<void> {
+    const response = await fetchWithAuth(
+      apiUrl(apiPaths.posts.remove(postId)),
+      {
+        method: 'DELETE',
+      }
+    );
+    const data = await parseJson(response);
+
+    if (!response.ok) {
+      throw new Error(
+        extractErrorMessage(data, `Failed to delete post (${response.status})`)
+      );
+    }
+  }
+
   async getPostsByGroupForView(groupId: number): Promise<Post[]> {
     try {
       return await this.getPostsByGroup(groupId);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -23,6 +23,7 @@ export interface Post {
 export interface Child {
   id: number;
   groupId?: number | null;
+  groupName?: string | null;
   firstName?: string | null;
   lastName?: string | null;
   dateOfBirth?: string | null;


### PR DESCRIPTION
## Summary

This PR adds post management to the Dashboard for teachers and admins.

### Included
- Add button and functionality to create posts for teacher and admin
- Add button and functionality to edit and delete posts for teacher and admin
- Create dialog to create and edit posts for teacher and admin
- Allow admins and teachers assigned to multiple groups to switch the active group
- Make relevant backend changes to support these flows

### Backend
- Add/update post API support for create, edit, and delete
- Use soft delete for posts
- Exclude soft-deleted posts from normal queries
- Update permissions to allow admin post management