### PR TITLE
feat: parent list view for admin and teachers

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import * as path from 'path';
-
 import { AuthModule } from './auth/auth.module';
 import { PostsModule } from './posts/posts.module';
 import { ChildrenModule } from './children/children.module';
@@ -15,6 +14,7 @@ import { LoggerModule } from 'nestjs-pino';
 import { appConfig } from './config';
 import { AbsencesModule } from './absences/absences.module';
 import { EventsModule } from './events/events.module';
+import { ParentsModule } from './parents/parents.module';
 
 @Module({
   imports: [
@@ -46,6 +46,7 @@ import { EventsModule } from './events/events.module';
     EventsModule,
     MailerModule,
     InvitesModule,
+    ParentsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/common/dto/parents.dto.ts
+++ b/backend/src/common/dto/parents.dto.ts
@@ -1,0 +1,8 @@
+export class ParentDto {
+    id: number;
+    email: string;
+    firstName: string | null;
+    lastName: string | null;
+    phone: string | null;
+    role: string;
+}

--- a/backend/src/common/dto/parents.dto.ts
+++ b/backend/src/common/dto/parents.dto.ts
@@ -1,8 +1,29 @@
+import { IsEmail, IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
 export class ParentDto {
-    id: number;
-    email: string;
-    firstName: string | null;
-    lastName: string | null;
-    phone: string | null;
-    role: string;
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    id!: number;
+
+    @IsEmail()
+    @IsNotEmpty()
+    email!: string;
+
+    @IsOptional()
+    @IsString()
+    firstName!: string | null;
+
+    @IsOptional()
+    @IsString()
+    lastName!: string | null;
+
+    @IsOptional()
+    @IsString()
+    phone!: string | null;
+
+    @IsString()
+    @IsNotEmpty()
+    role!: string;
 }

--- a/backend/src/parents/parents.controller.ts
+++ b/backend/src/parents/parents.controller.ts
@@ -26,7 +26,7 @@ export class ParentsController {
         status: 403,
         description: 'Forbidden — only ADMIN or TEACHER can access this.',
     })
-    async getAllParents(@Req() req: any): Promise<ParentDto[]> {
+    async getAllParents(@Req() req: { user: { id: number; role: string } }): Promise<ParentDto[]> {
         const user = req.user;
         return this.parentsService.findAllParents(user.id, user.role);
     }

--- a/backend/src/parents/parents.controller.ts
+++ b/backend/src/parents/parents.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiCookieAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ParentsService } from './parents.service';
+import { ParentDto } from '../common/dto/parents.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
@@ -18,13 +19,14 @@ export class ParentsController {
     @ApiOperation({ summary: 'Get all parent users (ADMIN/TEACHER only)' })
     @ApiResponse({
         status: 200,
-        description: 'List of parents returned successfully.'
+        description: 'List of parents returned successfully.',
+        type: [ParentDto],
     })
     @ApiResponse({
         status: 403,
-        description: 'Forbidden — only ADMIN or TEACHER can access this.'
+        description: 'Forbidden — only ADMIN or TEACHER can access this.',
     })
-    async getAllParents(): Promise<any[]> {
+    async getAllParents(): Promise<ParentDto[]> {
         return this.parentsService.findAllParents();
     }
 }

--- a/backend/src/parents/parents.controller.ts
+++ b/backend/src/parents/parents.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, UseGuards, Req } from '@nestjs/common';
 import { ApiCookieAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ParentsService } from './parents.service';
 import { ParentDto } from '../common/dto/parents.dto';
@@ -26,7 +26,8 @@ export class ParentsController {
         status: 403,
         description: 'Forbidden — only ADMIN or TEACHER can access this.',
     })
-    async getAllParents(): Promise<ParentDto[]> {
-        return this.parentsService.findAllParents();
+    async getAllParents(@Req() req: any): Promise<ParentDto[]> {
+        const user = req.user;
+        return this.parentsService.findAllParents(user.id, user.role);
     }
 }

--- a/backend/src/parents/parents.controller.ts
+++ b/backend/src/parents/parents.controller.ts
@@ -16,9 +16,15 @@ export class ParentsController {
     @Get()
     @Roles(ROLE.Admin, ROLE.Teacher)
     @ApiOperation({ summary: 'Get all parent users (ADMIN/TEACHER only)' })
-    @ApiResponse({ status: 200, description: 'List of parents returned successfully.' })
-    @ApiResponse({ status: 403, description: 'Forbidden — only ADMIN or TEACHER can access this.' })
-    async getParents() {
+    @ApiResponse({
+        status: 200,
+        description: 'List of parents returned successfully.'
+    })
+    @ApiResponse({
+        status: 403,
+        description: 'Forbidden — only ADMIN or TEACHER can access this.'
+    })
+    async getAllParents(): Promise<any[]> {
         return this.parentsService.findAllParents();
     }
 }

--- a/backend/src/parents/parents.controller.ts
+++ b/backend/src/parents/parents.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ParentsService } from './parents.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { ROLE } from 'database/schema';
+
+@ApiTags('parents')
+@ApiCookieAuth('jwt')
+@Controller('parents')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ParentsController {
+    constructor(private readonly parentsService: ParentsService) {}
+
+    @Get()
+    @Roles(ROLE.Admin, ROLE.Teacher)
+    @ApiOperation({ summary: 'Get all parent users (ADMIN/TEACHER only)' })
+    @ApiResponse({ status: 200, description: 'List of parents returned successfully.' })
+    @ApiResponse({ status: 403, description: 'Forbidden — only ADMIN or TEACHER can access this.' })
+    async getParents() {
+        return this.parentsService.findAllParents();
+    }
+}

--- a/backend/src/parents/parents.module.ts
+++ b/backend/src/parents/parents.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ParentsController } from './parents.controller';
+import { ParentsService } from './parents.service';
+
+@Module({
+    controllers: [ParentsController],
+    providers: [ParentsService],
+    exports: [ParentsService],
+})
+export class ParentsModule {}

--- a/backend/src/parents/parents.service.ts
+++ b/backend/src/parents/parents.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { db } from 'database/db';
-import { users, ROLE, groupUsers, enrollments, userChildren } from 'database/schema';
+import { users, groupUsers, enrollments, userChildren } from 'database/schema';
 import { and, eq, isNull, inArray } from 'drizzle-orm';
 import { ParentDto } from '../common/dto/parents.dto';
 

--- a/backend/src/parents/parents.service.ts
+++ b/backend/src/parents/parents.service.ts
@@ -2,10 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { db } from 'database/db';
 import { users, ROLE } from 'database/schema';
 import { and, eq, isNull } from 'drizzle-orm';
+import { ParentDto } from '../common/dto/parents.dto';
 
 @Injectable()
 export class ParentsService {
-    async findAllParents(): Promise<any[]> {
+    async findAllParents(): Promise<ParentDto[]> {
         const parentsList = await db
             .select({
                 id: users.id,

--- a/backend/src/parents/parents.service.ts
+++ b/backend/src/parents/parents.service.ts
@@ -5,7 +5,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 
 @Injectable()
 export class ParentsService {
-    async findAllParents() {
+    async findAllParents(): Promise<any[]> {
         const parentsList = await db
             .select({
                 id: users.id,

--- a/backend/src/parents/parents.service.ts
+++ b/backend/src/parents/parents.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { db } from 'database/db';
+import { users, ROLE } from 'database/schema';
+import { and, eq, isNull } from 'drizzle-orm';
+
+@Injectable()
+export class ParentsService {
+    async findAllParents() {
+        const parentsList = await db
+            .select({
+                id: users.id,
+                email: users.email,
+                firstName: users.firstName,
+                lastName: users.lastName,
+                phone: users.phone,
+                role: users.role,
+            })
+            .from(users)
+            .where(
+                and(
+                    eq(users.role, ROLE.Parent),
+                    isNull(users.deletedAt)
+                )
+            );
+
+        return parentsList;
+    }
+}

--- a/backend/src/parents/parents.service.ts
+++ b/backend/src/parents/parents.service.ts
@@ -1,13 +1,44 @@
 import { Injectable } from '@nestjs/common';
 import { db } from 'database/db';
-import { users, ROLE } from 'database/schema';
-import { and, eq, isNull } from 'drizzle-orm';
+import { users, ROLE, groupUsers, enrollments, userChildren } from 'database/schema';
+import { and, eq, isNull, inArray } from 'drizzle-orm';
 import { ParentDto } from '../common/dto/parents.dto';
 
 @Injectable()
 export class ParentsService {
-    async findAllParents(): Promise<ParentDto[]> {
-        const parentsList = await db
+    async findAllParents(requestingUserId: number, role: string): Promise<ParentDto[]> {
+        // 1. Kui on ADMIN, näitame kõiki (nagu varem)
+        if (role === 'ADMIN') {
+            return db
+                .select({
+                    id: users.id,
+                    email: users.email,
+                    firstName: users.firstName,
+                    lastName: users.lastName,
+                    phone: users.phone,
+                    role: users.role,
+                })
+                .from(users)
+                .where(and(eq(users.role, 'PARENT'), isNull(users.deletedAt)));
+        }
+
+        const teacherGroups = db
+            .select({ groupId: groupUsers.groupId })
+            .from(groupUsers)
+            .where(eq(groupUsers.userId, requestingUserId));
+
+        const childrenInGroups = db
+            .select({ childId: enrollments.childId })
+            .from(enrollments)
+            .where(inArray(enrollments.groupId, teacherGroups));
+
+        // Siin kasutame nüüd õiget tabeli nime: userChildren
+        const parentIds = db
+            .select({ userId: userChildren.userId })
+            .from(userChildren)
+            .where(inArray(userChildren.childId, childrenInGroups));
+
+        return db
             .select({
                 id: users.id,
                 email: users.email,
@@ -19,11 +50,10 @@ export class ParentsService {
             .from(users)
             .where(
                 and(
-                    eq(users.role, ROLE.Parent),
-                    isNull(users.deletedAt)
+                    eq(users.role, 'PARENT'),
+                    isNull(users.deletedAt),
+                    inArray(users.id, parentIds)
                 )
             );
-
-        return parentsList;
     }
 }

--- a/backend/test/parents/parents.controller.spec.ts
+++ b/backend/test/parents/parents.controller.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ParentsController } from '../../src/parents/parents.controller';
+import { ParentsService } from '../../src/parents/parents.service';
+
+describe('ParentsController', () => {
+    let controller: ParentsController;
+    let service: ParentsService;
+
+    const mockParents = [
+        { id: 1, email: 'test@test.ee', firstName: 'Kalle', lastName: 'Kuusk', role: 'PARENT' }
+    ];
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [ParentsController],
+            providers: [
+                {
+                    provide: ParentsService,
+                    useValue: {
+                        findAllParents: jest.fn().mockResolvedValue(mockParents),
+                    },
+                },
+            ],
+        }).compile();
+
+        controller = module.get<ParentsController>(ParentsController);
+        service = module.get<ParentsService>(ParentsService);
+    });
+
+    it('should be defined', () => {
+        expect(controller).toBeDefined();
+    });
+
+    it('should return parents list', async () => {
+        // We pass a mock request object with the user role
+        const mockReq = { user: { id: 1, role: 'ADMIN' } } as any;
+        const result = await controller.getAllParents(mockReq);
+        expect(result).toEqual(mockParents);
+    });
+});

--- a/backend/test/parents/parents.controller.spec.ts
+++ b/backend/test/parents/parents.controller.spec.ts
@@ -4,7 +4,6 @@ import { ParentsService } from '../../src/parents/parents.service';
 
 describe('ParentsController', () => {
     let controller: ParentsController;
-    let service: ParentsService;
 
     const mockParents = [
         { id: 1, email: 'test@test.ee', firstName: 'Kalle', lastName: 'Kuusk', role: 'PARENT' }
@@ -24,7 +23,6 @@ describe('ParentsController', () => {
         }).compile();
 
         controller = module.get<ParentsController>(ParentsController);
-        service = module.get<ParentsService>(ParentsService);
     });
 
     it('should be defined', () => {
@@ -33,7 +31,7 @@ describe('ParentsController', () => {
 
     it('should return parents list', async () => {
         // We pass a mock request object with the user role
-        const mockReq = { user: { id: 1, role: 'ADMIN' } } as any;
+        const mockReq = { user: { id: 1, role: 'ADMIN' } };
         const result = await controller.getAllParents(mockReq);
         expect(result).toEqual(mockParents);
     });

--- a/backend/test/parents/parents.service.e2e-spec.ts
+++ b/backend/test/parents/parents.service.e2e-spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ParentsService } from '../../src/parents/parents.service';
+import { ROLE } from '../../src/database/schema';
+
+describe('ParentsService (e2e)', () => {
+    let service: ParentsService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [ParentsService],
+        }).compile();
+
+        service = module.get<ParentsService>(ParentsService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+
+    // We add a dummy test to satisfy Jest's "at least one test" rule
+    it('should return a list (can be empty)', async () => {
+        // Note: In a real E2E, this would hit the DB.
+        // We just need Jest to see a valid 'it' block.
+        expect(service.findAllParents).toBeDefined();
+    });
+});

--- a/backend/test/parents/parents.service.e2e-spec.ts
+++ b/backend/test/parents/parents.service.e2e-spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ParentsService } from '../../src/parents/parents.service';
-import { ROLE } from '../../src/database/schema';
 
 describe('ParentsService (e2e)', () => {
     let service: ParentsService;

--- a/frontend/src/app/(main)/parents/page.tsx
+++ b/frontend/src/app/(main)/parents/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { ParentsTable } from '@/components/parents/ParentsTable';
+import { showErrorToast } from '@/components/ErrorToast';
+import { useUserRole } from '@/context/UserRoleContext';
+import parentService from '@/services/parent.service';
+import type { User } from '@/types';
+import { USER_ROLE } from '@/types/enums';
+
+export default function ParentsPage() {
+    const router = useRouter();
+    const { role, loading: roleLoading } = useUserRole();
+    const [parents, setParents] = useState<User[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    const hasAccess = role === USER_ROLE.ADMIN || role === USER_ROLE.TEACHER;
+
+    const loadParents = useCallback(async () => {
+        setLoading(true);
+        try {
+            const data = await parentService.getAllParentsList();
+            setParents(data);
+        } catch (error) {
+            const err = error as Error;
+            showErrorToast(err.message || 'Failed to load parents');
+            setParents([]);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (roleLoading) return;
+        if (!hasAccess) router.replace('/dashboard');
+    }, [hasAccess, roleLoading, router]);
+
+    useEffect(() => {
+        if (roleLoading || !hasAccess) return;
+        void loadParents();
+    }, [hasAccess, loadParents, roleLoading]);
+
+    if (roleLoading || !hasAccess) return null;
+
+    return (
+        <Box sx={{ display: 'grid', gap: 3 }}>
+            <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                justifyContent="space-between"
+                alignItems={{ xs: 'flex-start', sm: 'center' }}
+                spacing={2}
+            >
+                <Box>
+                    <Typography variant="h4" sx={{ fontWeight: 700 }}>
+                        Lapsevanemad
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                        Sirvige platvormi lapsevanemaid ja nende kontaktandmeid.
+                    </Typography>
+                </Box>
+            </Stack>
+
+            <ParentsTable rows={parents} loading={loading || roleLoading} />
+        </Box>
+    );
+}

--- a/frontend/src/components/parents/ParentsTable.tsx
+++ b/frontend/src/components/parents/ParentsTable.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+import type { User } from '@/types';
+
+type ParentsTableProps = {
+    rows: User[];
+    loading: boolean;
+};
+
+export function ParentsTable({ rows, loading }: ParentsTableProps) {
+    const [page, setPage] = React.useState(0);
+    const [rowsPerPage, setRowsPerPage] = React.useState(10);
+
+    React.useEffect(() => {
+        const maxPage = Math.max(0, Math.ceil(rows.length / rowsPerPage) - 1);
+        if (page > maxPage) {
+            setPage(maxPage);
+        }
+    }, [page, rows.length, rowsPerPage]);
+
+    const paginatedRows = React.useMemo(() => {
+        const start = page * rowsPerPage;
+        return rows.slice(start, start + rowsPerPage);
+    }, [page, rows, rowsPerPage]);
+
+    return (
+        <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
+            <TableContainer>
+                <Table size="medium">
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>ID</TableCell>
+                            <TableCell>Eesnimi</TableCell>
+                            <TableCell>Perekonnanimi</TableCell>
+                            <TableCell>Email</TableCell>
+                            <TableCell>Telefon</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {loading ? (
+                            <TableRow>
+                                <TableCell colSpan={5}>
+                                    <Typography variant="body2" color="text.secondary">
+                                        Laadimine...
+                                    </Typography>
+                                </TableCell>
+                            </TableRow>
+                        ) : paginatedRows.length === 0 ? (
+                            <TableRow>
+                                <TableCell colSpan={5}>
+                                    <Typography variant="body2" color="text.secondary">
+                                        Lapsevanemaid ei leitud.
+                                    </Typography>
+                                </TableCell>
+                            </TableRow>
+                        ) : (
+                            paginatedRows.map((parent) => (
+                                <TableRow key={parent.id} hover>
+                                    <TableCell>{parent.id}</TableCell>
+                                    <TableCell>{parent.firstName || '-'}</TableCell>
+                                    <TableCell>{parent.lastName || '-'}</TableCell>
+                                    <TableCell>{parent.email}</TableCell>
+                                    <TableCell>{parent.phone || '-'}</TableCell>
+                                </TableRow>
+                            ))
+                        )}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+            <TablePagination
+                component="div"
+                count={rows.length}
+                page={page}
+                onPageChange={(_event, nextPage) => setPage(nextPage)}
+                rowsPerPage={rowsPerPage}
+                onRowsPerPageChange={(event) => {
+                    setRowsPerPage(parseInt(event.target.value, 10));
+                    setPage(0);
+                }}
+                rowsPerPageOptions={[5, 10, 25]}
+                labelRowsPerPage="Ridu lehel:"
+            />
+        </Paper>
+    );
+}

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -92,6 +92,9 @@ export const apiPaths = {
   invites: {
     create: '/invites',
   },
+  parents: {
+    list: '/parents',
+  },
 };
 
 export function apiUrl(path: string): string {

--- a/frontend/src/config/main-nav.ts
+++ b/frontend/src/config/main-nav.ts
@@ -33,7 +33,8 @@ export type MainNavItem = {
 export const mainNav: MainNavItem[] = [
   { href: '/users', label: 'Kasutajad', Icon: UserPlus, mobile: 'overflow', roles: ['ADMIN'] },
   { href: '/groups', label: 'Grupid', Icon: Users, mobile: 'overflow', roles: ['ADMIN'] },
-  { href: '/children', label: 'Lapsed', Icon: Baby, mobile: 'overflow', roles: ['ADMIN'] },
+  { href: '/children', label: 'Lapsed', Icon: Baby, mobile: 'overflow', roles: ['ADMIN', 'TEACHER'] },
+  { href: '/parents', label: 'Lapsevanemad', Icon: Users, mobile: 'overflow', roles: ['ADMIN', 'TEACHER'] },
   { href: '/dashboard', label: 'Avaleht', Icon: Home, mobile: 'dock'},
   { href: '/announcements', label: 'Teated', Icon: Bell, mobile: 'dock' },
   { href: '/calendar', label: 'Kalender', Icon: Calendar, mobile: 'dock' },

--- a/frontend/src/services/parent.service.ts
+++ b/frontend/src/services/parent.service.ts
@@ -1,0 +1,26 @@
+import { User } from '@/types';
+import { apiPaths, apiUrl } from '@/config/api';
+import {
+    extractErrorMessage,
+    fetchWithAuth,
+    parseJson,
+    unwrapData,
+} from '@/services/http.service';
+
+class ParentService {
+    async getAllParentsList(): Promise<User[]> {
+        const response = await fetchWithAuth(apiUrl(apiPaths.parents.list));
+        const data = await parseJson(response);
+
+        if (!response.ok) {
+            throw new Error(extractErrorMessage(data, `Failed to load parents (${response.status})`));
+        }
+
+        // Since our backend returns fields matching the User type, we can cast it
+        return unwrapData<User[]>(data, []);
+    }
+}
+
+const parentService = new ParentService();
+
+export default parentService;


### PR DESCRIPTION
<img width="1353" height="448" alt="image" src="https://github.com/user-attachments/assets/c64c2d15-57ac-4046-abc6-8ef2deed247e" />

Created a list for ADMIN & TEACHER roles to access the existing list Parents. 
Current search logic which returns the parents list works on the search
SELECT * FROM users WHERE role = 'PARENT' AND deleted_at IS NULL;